### PR TITLE
feat: add svm guide warnings 

### DIFF
--- a/docs/guides/warp-routes/svm/svm-warp-route-guide.mdx
+++ b/docs/guides/warp-routes/svm/svm-warp-route-guide.mdx
@@ -43,6 +43,8 @@ Deploying a HWR requires there to be a core Hyperlane deployment that is connect
 
 2. Build the HWR programs on your machine.
 
+   {" "}
+
    <Note>
      `solana-cli 1.14.20` is required for building HWR programs, but it is not
      required to manually install it. The `./build-programs.sh` script will
@@ -60,6 +62,15 @@ Deploying a HWR requires there to be a core Hyperlane deployment that is connect
    This [script](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/rust/sealevel/programs/build-programs.sh) will **compile the Solana programs**, which is needed for deployment. It will use the `solana-cli 1.14.20` automatically and reset back to the previously used version afterward.
 
    To verify the build output, check the target/deploy directory for `.so` files in `hyperlane-monorepo/rust/sealevel/target/deploy`
+
+   <Note>
+     During the build process, you may encounter a stack offset error message
+     like `Error: Function [...] Stack offset of 4360 exceeded max offset of xx
+     ..`. This is a known issue that has no impact on the functionality of the
+     programs. The error relates to an unused function in a dependency crate and
+     can be ignored. The programs will build, deploy, and function correctly
+     despite this warning.
+   </Note>
 
 ### Step 2: Prepare for Deployment
 

--- a/docs/guides/warp-routes/svm/svm-warp-route-guide.mdx
+++ b/docs/guides/warp-routes/svm/svm-warp-route-guide.mdx
@@ -43,8 +43,6 @@ Deploying a HWR requires there to be a core Hyperlane deployment that is connect
 
 2. Build the HWR programs on your machine.
 
-   {" "}
-
    <Note>
      `solana-cli 1.14.20` is required for building HWR programs, but it is not
      required to manually install it. The `./build-programs.sh` script will

--- a/docs/operate/relayer/run-relayer.mdx
+++ b/docs/operate/relayer/run-relayer.mdx
@@ -91,6 +91,10 @@ Hyperlane Validators and Relayers can use **multiple RPC URLs** to improve relia
       For **SVM chains**, only a **single RPC URL** is used. There is no fallback or quorum-based selection mechanism.
     </Warning>
 
+    <Warning>
+      **SVM Relayer Funding**: When relaying messages to SVM chains, make sure your Relayer key has sufficient funds on the destination chain. The Relayer performs view calls via simulations that require the sender to have funds for successful simulation, even for read operations. Without sufficient funds, you may encounter `No return data from InboxGetRecipientIsm instruction` errors.
+    </Warning>
+
   </Tab>
 </Tabs>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that a stack offset warning during the build of Hyperlane Warp Route programs is harmless and can be safely ignored.
  * Added a warning that relaying messages to SVM chains requires the Relayer's signing key to have sufficient funds on the destination chain, even for simulation-based view calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->