### PR TITLE
Add docs on HTTP API

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -310,6 +310,7 @@
             "group": "Relayer",
             "pages": [
               "docs/operate/relayer/run-relayer",
+              "docs/operate/relayer/api",
               "docs/operate/relayer/message-filtering",
               "docs/operate/relayer/monitoring-alerting"
             ]

--- a/docs/operate/relayer/api.mdx
+++ b/docs/operate/relayer/api.mdx
@@ -1,0 +1,66 @@
+---
+title: "Relayer API"
+---
+
+The relayer provides a comprehensive HTTP API for inspecting database contents and managing operations. Based on the server module implementation `mod.rs:65-93`, here's the complete API specification:
+
+## Messages API
+
+### GET /messages
+
+Query Parameters:
+- `domain_id` (u32): Chain domain ID
+- `nonce_start` (u32): Starting nonce (inclusive)  
+- `nonce_end` (u32): Ending nonce (inclusive)
+
+**Response:** Array of HyperlaneMessage objects
+
+**Validation:** Requires `nonce_end > nonce_start`, returns 400 if invalid
+
+### POST /messages
+
+**Body:** Message data for insertion
+
+**Purpose:** Insert new messages into the database
+
+## Operation Queue API
+
+### GET /operations
+
+**Purpose:** List pending messages in operation queues `mod.rs:74-75`
+
+**Response:** Current messages being processed by the relayer
+
+## Message Retry API
+
+### POST /retry
+
+**Purpose:** Trigger retry of failed messages `mod.rs:69-72`
+
+**Body:** Message retry request matching specific patterns
+
+## Merkle Tree API
+
+### GET /merkle-tree-insertions
+
+**Purpose:** Inspect merkle tree insertion events `mod.rs:80`
+
+**Response:** Merkle tree data stored in the database
+
+## IGP (Interchain Gas Payment) Management API
+
+### GET /igp/rules
+
+**Purpose:** List current IGP rules
+
+### POST /igp/rules
+
+**Purpose:** Add new IGP rules
+
+### DELETE /igp/rules
+
+**Purpose:** Remove existing IGP rules
+
+<Note>
+These endpoints are available when gas enforcers are configured `mod.rs:82-83`.
+</Note>

--- a/docs/operate/relayer/api.mdx
+++ b/docs/operate/relayer/api.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Relayer API"
+title: "Relayer HTTP API"
 ---
 
 The relayer provides a comprehensive HTTP API for inspecting database contents and managing operations. Based on the server module implementation `mod.rs:65-93`, here's the complete API specification:
@@ -9,8 +9,9 @@ The relayer provides a comprehensive HTTP API for inspecting database contents a
 ### GET /messages
 
 Query Parameters:
+
 - `domain_id` (u32): Chain domain ID
-- `nonce_start` (u32): Starting nonce (inclusive)  
+- `nonce_start` (u32): Starting nonce (inclusive)
 - `nonce_end` (u32): Ending nonce (inclusive)
 
 **Response:** Array of HyperlaneMessage objects
@@ -62,5 +63,5 @@ Query Parameters:
 **Purpose:** Remove existing IGP rules
 
 <Note>
-These endpoints are available when gas enforcers are configured `mod.rs:82-83`.
+  These endpoints are available when gas enforcers are configured `mod.rs:82-83`.
 </Note>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a “Relayer HTTP API” page under Agent Operators > Relayer in the docs navigation.
  * Documents endpoints for:
    - Messages: GET (filter by domain_id and nonce range) and POST (insert).
    - Operation Queue: GET (list pending).
    - Message Retry: POST (trigger retries).
    - Merkle Tree insertions: GET (inspect events).
    - IGP Rules: GET/POST/DELETE (manage rules).
  * Notes include parameter validation (nonce_end > nonce_start) and availability of IGP endpoints when gas enforcers are configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->