### PR TITLE
Add reprocess docs

### DIFF
--- a/docs/operate/relayer/api.mdx
+++ b/docs/operate/relayer/api.mdx
@@ -19,6 +19,11 @@ The following endpoints are available for interacting with the relayer:
 ### Operation Management
 - [List Operations](/docs/operate/relayer/api/operations/get-operations) - View pending messages in operation queues
 - [Retry Messages](/docs/operate/relayer/api/operations/post-message-retry) - Trigger retry of failed messages
+- [Reprocess Message](/docs/operate/relayer/api/operations/post-reprocess-message) - Re-queue messages for processing on demand
+
+<Info>
+**Retry vs Reprocess**: Retry handles failed messages currently in the operation queues (memory), while reprocess re-queues messages from the database (storage) for processing - either already-delivered messages that need reprocessing or to allow external services to trigger message delivery instead of relying on queue backoff.
+</Info>
 
 ### Data Inspection
 - [Get Merkle Tree Insertions](/docs/operate/relayer/api/merkle-tree-insertions/get-merkle-tree-insertions) - Query merkle tree insertion in the database

--- a/docs/operate/relayer/api.mdx
+++ b/docs/operate/relayer/api.mdx
@@ -18,7 +18,7 @@ The following endpoints are available for interacting with the relayer:
 
 ### Operation Management
 - [List Operations](/docs/operate/relayer/api/operations/get-operations) - View pending messages in operation queues
-- [Retry Messages](/docs/operate/relayer/api/operations/post-message-retry) - Trigger retry of failed messages
+- [Retry Messages](/docs/operate/relayer/api/operations/post-message-retry) - Trigger retry of failed messages (resets retry count)
 - [Reprocess Message](/docs/operate/relayer/api/operations/post-reprocess-message) - Re-queue messages for processing on demand
 
 <Info>

--- a/docs/operate/relayer/api/operations/post-message-retry.mdx
+++ b/docs/operate/relayer/api/operations/post-message-retry.mdx
@@ -3,7 +3,7 @@ title: 'Retry Messages'
 api: 'POST http://localhost:9090/message_retry'
 ---
 
-Trigger retry of failed messages matching specific patterns.
+Trigger retry of failed messages matching specific patterns. This resets the retry count to 0 and re-queues the messages for processing.
 
 <Expandable title="Request Body">
   <Expandable title="Array of objects">

--- a/docs/operate/relayer/api/operations/post-reprocess-message.mdx
+++ b/docs/operate/relayer/api/operations/post-reprocess-message.mdx
@@ -1,0 +1,79 @@
+---
+title: 'Reprocess Message'
+api: 'POST http://localhost:9090/reprocess_message'
+---
+
+Reprocess a message that has already been marked as delivered. This endpoint is useful for handling scenarios like blockchain network reorganizations where messages might have been incorrectly processed.
+
+<Expandable title="Request Body">
+  <ParamField body="origin_id" type="u32" required>
+    Domain/chain ID where the message originated
+  </ParamField>
+  <ParamField body="message_id" type="string" required>
+    Hex-encoded message identifier (H256)
+  </ParamField>
+</Expandable>
+
+<Expandable title="Response Body">
+  <ResponseField name="success" type="boolean">
+    Whether the message was successfully re-queued for processing
+  </ResponseField>
+  <ResponseField name="message" type="string">
+    Details about the reprocessing operation
+  </ResponseField>
+</Expandable>
+
+<RequestExample>
+```bash curl
+curl -X POST "http://localhost:9090/reprocess_message" \
+  -H "Content-Type: application/json" \
+  -d \
+'{
+  "origin_id": 1399811149,
+  "message_id": "0x9484bd5c635b17b28cb382249d7a6fe5ca15debfd4f824247c68d47badc5b7de"
+}'
+```
+
+```javascript JavaScript
+const response = await fetch('http://localhost:9090/reprocess_message', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({
+    origin_id: 1399811149,
+    message_id: "0x9484bd5c635b17b28cb382249d7a6fe5ca15debfd4f824247c68d47badc5b7de"
+  })
+});
+```
+
+```python Python
+import requests
+
+response = requests.post('http://localhost:9090/reprocess_message', json={
+  'origin_id': 1399811149,
+  'message_id': '0x9484bd5c635b17b28cb382249d7a6fe5ca15debfd4f824247c68d47badc5b7de'
+})
+```
+</RequestExample>
+
+<ResponseExample>
+```json Success Response
+{
+  "success": true,
+  "message": "Message re-queued for processing"
+}
+```
+
+```json Error Response (400 Bad Request)
+{
+  "error": "Invalid message_id format"
+}
+```
+
+```json Error Response (404 Not Found)
+{
+  "error": "Message or context not found"
+}
+```
+</ResponseExample>

--- a/docs/operate/relayer/api/operations/post-reprocess-message.mdx
+++ b/docs/operate/relayer/api/operations/post-reprocess-message.mdx
@@ -3,7 +3,7 @@ title: 'Reprocess Message'
 api: 'POST http://localhost:9090/reprocess_message'
 ---
 
-Reprocess a message that has already been marked as delivered. This endpoint is useful for handling scenarios like blockchain network reorganizations where messages might have been incorrectly processed.
+Re-queue a message for processing on demand. This endpoint allows external services to trigger message delivery instead of relying on queue backoff, and can handle scenarios like blockchain network reorganizations or manual message processing.
 
 <Expandable title="Request Body">
   <ParamField body="origin_id" type="u32" required>

--- a/docs/operate/relayer/api/operations/post-reprocess-message.mdx
+++ b/docs/operate/relayer/api/operations/post-reprocess-message.mdx
@@ -5,6 +5,10 @@ api: 'POST http://localhost:9090/reprocess_message'
 
 Re-queue a message for processing on demand. This endpoint allows external services to trigger message delivery instead of relying on queue backoff, and can handle scenarios like blockchain network reorganizations or manual message processing.
 
+<Note>
+For purely on-demand processing without automatic retries, combine this endpoint with `max_message_retries := 0` in your relayer configuration. This ensures messages are only processed when explicitly triggered via this API.
+</Note>
+
 <Expandable title="Request Body">
   <ParamField body="origin_id" type="u32" required>
     Domain/chain ID where the message originated


### PR DESCRIPTION
document new endpoint introduced in https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/6981

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added docs for a new Reprocess Message endpoint (POST /reprocess_message) enabling on-demand re-queuing from storage.
  * Clarified Retry Messages behavior: triggering a retry now explicitly resets the retry count to 0 and re-queues matching messages.
  * Added an info section contrasting Retry (in-memory queue) vs Reprocess (from storage, including previously delivered).
  * Provided request/response details, error cases (400, 404), and examples in cURL, JavaScript, and Python.
  * Noted configuration tip: max_message_retries = 0 for on-demand processing only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->