### PR TITLE
clarify SVM RPC fallback behavior

### DIFF
--- a/docs/operate/relayer/run-relayer.mdx
+++ b/docs/operate/relayer/run-relayer.mdx
@@ -83,12 +83,12 @@ Hyperlane Validators and Relayers can use **multiple RPC URLs** to improve relia
   </Tab>
   
   <Tab title="SVM Chains">
-    SVM-based chains support configuring multiple RPC endpoints, but **only a single RPC is used**.
+    SVM-based chains support configuring multiple RPC endpoints. Agents automatically use **fallback mode**: if the current RPC fails or times out, they switch to the next available endpoint.
 
     - **Configure RPCs:** Use [`customRpcUrls`](/docs/operate/config/config-reference#chains-<chain-name>-customrpcurls).
 
     <Warning>
-      For **SVM chains**, only a **single RPC URL** is used. There is no fallback or quorum-based selection mechanism.
+      For **SVM chains**, only **Fallback mode** is supported. SVM agents will automatically switch between configured RPC URLs when encountering errors or timeouts.
     </Warning>
 
     <Warning>


### PR DESCRIPTION
## Summary
Clarifies how SVM chains handle multiple RPC endpoints 

## Changes
- Updated main description to explicitly state that SVM uses automatic fallback
- Updated warning box 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified SVM Chains RPC behavior: only Fallback mode is supported.
  * Explained that agents automatically switch to the next configured RPC endpoint on errors or timeouts.
  * Updated setup guidance to reflect configuring multiple RPC URLs for improved resilience.
  * Refined warnings to set expectations around failover behavior and reliability during endpoint outages.
  * Improved overall instructions to help users understand runtime behavior when an RPC endpoint becomes unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->