### PR TITLE
Update warp route docs with fees

### DIFF
--- a/docs/applications/warp-routes/interface.mdx
+++ b/docs/applications/warp-routes/interface.mdx
@@ -18,8 +18,91 @@ interface IHypERC20 is IERC20 {
         bytes32 _recipient,
         uint256 _amount
     ) external payable;
+
+    /**
+     * @notice Quotes the fees required for a remote transfer
+     * @param _destination The domain ID of the destination chain
+     * @param _recipient The address of the recipient, encoded as bytes32
+     * @param _amount The amount of tokens to transfer
+     * @return quotes An array of Quote structs representing fees in different tokens
+     */
+    function quoteTransferRemote(
+        uint32 _destination,
+        bytes32 _recipient,
+        uint256 _amount
+    ) external view returns (Quote[] memory quotes);
+}
+
+struct Quote {
+    address token; // Token address (address(0) for native token)
+    uint256 amount; // Fee amount in the specified token
 }
 ```
+
+## Fee Quoting Interface
+
+<Info>
+  New in version 10.0.0: The `quoteTransferRemote` function provides a standardized way to quote fees for warp route transfers.
+</Info>
+
+### Quote Structure
+
+The `quoteTransferRemote` function returns an array of exactly 3 `Quote` structs with the following convention:
+
+1. **Index 0: Native Mailbox Dispatch Fee**
+   - Token: `address(0)` (native token like ETH, MATIC, etc.)
+   - Amount: Fee charged by the Hyperlane mailbox for dispatching the message
+   - This must be sent as `msg.value` when calling `transferRemote`
+
+2. **Index 1: Internal Token Amount**
+   - Token: The warp route token address (from `token()` function)
+   - Amount: `_amount + internalFeeAmount`
+   - This is the total amount of tokens that must be sent/approved, including any internal fees charged by the warp route
+
+3. **Index 2: External Bridge Fee**
+   - Token: The warp route token address (from `token()` function)
+   - Amount: Additional fees for external bridges (e.g., CCTP, Everclear), or `0` if none
+   - This is included in the total amount required at index 1
+
+### Exact Amount Out Semantics
+
+Warp routes use "exact amount out" semantics, meaning:
+
+- The `_amount` parameter in `transferRemote` specifies the **exact amount the recipient receives**
+- Fees are charged **on top** of this amount from the sender
+- Total tokens required = `_amount + internalFeeAmount + externalFeeAmount`
+
+**Example:**
+
+```solidity
+// Get fee quote
+Quote[] memory quotes = warpRoute.quoteTransferRemote(
+    destinationDomain,
+    recipientAddress,
+    1000e18  // Recipient will receive exactly 1000 tokens
+);
+
+// quotes[0]: Native fee (e.g., 0.01 ETH)
+// quotes[1]: Token amount (e.g., 1005e18 = 1000 + 5 fee)
+// quotes[2]: External fee (e.g., 0 or included in quotes[1])
+
+// Approve total token amount
+IERC20(warpRoute.token()).approve(
+    address(warpRoute),
+    quotes[1].amount  // 1005e18 total
+);
+
+// Transfer with native fee
+warpRoute.transferRemote{value: quotes[0].amount}(
+    destinationDomain,
+    recipientAddress,
+    1000e18  // Recipient receives exactly 1000 tokens
+);
+```
+
+<Warning>
+  **Important:** Always query fees on-chain immediately before the transfer, as fees may change based on gas prices, exchange rates, or route configuration.
+</Warning>
 
 ## Deploy your HWR
 

--- a/docs/applications/warp-routes/interface.mdx
+++ b/docs/applications/warp-routes/interface.mdx
@@ -2,22 +2,26 @@
 title: "HWR Interface"
 ---
 
-Hyperlane Warp Routes (HWR) leverage the `IHypERC20` token interface. HWR tokens implement this interface, which extends the standard `ERC20` interface.
+Hyperlane Warp Routes (HWR) implement the `ITokenBridge` interface.
 
 ```solidity
-/// @notice An interchain extension of the ERC20 interface
-interface IHypERC20 is IERC20 {
+interface ITokenBridge {
     /**
      * @notice Transfers tokens to the specified recipient on a remote chain
      * @param _destination The domain ID of the destination chain
      * @param _recipient The address of the recipient, encoded as bytes32
-     * @param _amount The amount of tokens to transfer
+     * @param _amount The amount of tokens the recipient should receive
      */
     function transferRemote(
         uint32 _destination,
         bytes32 _recipient,
         uint256 _amount
     ) external payable;
+
+    struct Quote {
+        address token; // Token address (address(0) for native token)
+        uint256 amount; // Fee amount in the specified token
+    }
 
     /**
      * @notice Quotes the fees required for a remote transfer
@@ -32,37 +36,28 @@ interface IHypERC20 is IERC20 {
         uint256 _amount
     ) external view returns (Quote[] memory quotes);
 }
-
-struct Quote {
-    address token; // Token address (address(0) for native token)
-    uint256 amount; // Fee amount in the specified token
-}
 ```
 
 ## Fee Quoting Interface
 
 <Info>
   New in version 10.0.0: The `quoteTransferRemote` function provides a standardized way to quote fees for warp route transfers.
+  Only applicable to routes that return >= 10.0.0 from `PACKAGE_VERSION()`.
 </Info>
 
 ### Quote Structure
 
-The `quoteTransferRemote` function returns an array of exactly 3 `Quote` structs with the following convention:
+The `quoteTransferRemote` function returns an array of `Quote` structs with the following convention:
 
-1. **Index 0: Native Mailbox Dispatch Fee**
+1. **Index 0: Native Fees**
    - Token: `address(0)` (native token like ETH, MATIC, etc.)
-   - Amount: Fee charged by the Hyperlane mailbox for dispatching the message
+   - Amount: Fees charged by the mailbox for dispatching the message
    - This must be sent as `msg.value` when calling `transferRemote`
 
-2. **Index 1: Internal Token Amount**
-   - Token: The warp route token address (from `token()` function)
+2. **Index 1: Token Fees**
+   - Token: The ERC20 token being bridged.
    - Amount: `_amount + internalFeeAmount`
    - This is the total amount of tokens that must be sent/approved, including any internal fees charged by the warp route
-
-3. **Index 2: External Bridge Fee**
-   - Token: The warp route token address (from `token()` function)
-   - Amount: Additional fees for external bridges (e.g., CCTP, Everclear), or `0` if none
-   - This is included in the total amount required at index 1
 
 ### Exact Amount Out Semantics
 
@@ -82,18 +77,20 @@ Quote[] memory quotes = warpRoute.quoteTransferRemote(
     1000e18  // Recipient will receive exactly 1000 tokens
 );
 
-// quotes[0]: Native fee (e.g., 0.01 ETH)
-// quotes[1]: Token amount (e.g., 1005e18 = 1000 + 5 fee)
-// quotes[2]: External fee (e.g., 0 or included in quotes[1])
+// quotes[0]: Native fee (e.g., 0.00001 ETH)
+uint256 nativeFee = quotes[0].amount;
 
-// Approve total token amount
-IERC20(warpRoute.token()).approve(
+// quotes[1]: Token amount (e.g., 1001e18 = 1000 + 1 fee)
+uint256 tokenFee = quotes[1].amount;
+
+// Approve warp route for token transfer
+IERC20(quotes[1].token).approve(
     address(warpRoute),
-    quotes[1].amount  // 1005e18 total
+    tokenFee  // 1001e18 total
 );
 
 // Transfer with native fee
-warpRoute.transferRemote{value: quotes[0].amount}(
+warpRoute.transferRemote{value: nativeFee}(
     destinationDomain,
     recipientAddress,
     1000e18  // Recipient receives exactly 1000 tokens
@@ -101,7 +98,7 @@ warpRoute.transferRemote{value: quotes[0].amount}(
 ```
 
 <Warning>
-  **Important:** Always query fees on-chain immediately before the transfer, as fees may change based on gas prices, exchange rates, or route configuration.
+  **Important:** Always query fees immediately before the transfer with the consistent parameters, as fees may change based on destination, recipient, amount, gas prices, exchange rates, or warp route configuration.
 </Warning>
 
 ## Deploy your HWR

--- a/docs/guides/warp-routes/evm/transfer-and-call-pattern.mdx
+++ b/docs/guides/warp-routes/evm/transfer-and-call-pattern.mdx
@@ -95,22 +95,22 @@ function transferAndCall(
     );
 
     // Extract the native mailbox dispatch fee (index 0)
-    uint256 warpFee = quotes[0].amount;
+    uint256 nativeFee = quotes[0].amount;
 
-    // Extract the total token amount including internal fees (index 1)
-    uint256 totalTokenAmount = quotes[1].amount;
+    // Extract the total token amount charged by the warp route
+    uint256 tokenFee = quotes[1].amount;
 
     // Transfer the total token amount from the sender to this contract
-    asset.transferFrom(msg.sender, address(this), totalTokenAmount);
+    asset.transferFrom(msg.sender, address(this), tokenFee);
 
     // Approve the warp route to spend the tokens
-    asset.approve(address(warpRoute), totalTokenAmount);
+    asset.approve(address(warpRoute), tokenFee);
 
     // Initiate the HWR transfer to send tokens cross-chain
-    warpRoute.transferRemote{value: warpFee}(destination, self, amount);
+    warpRoute.transferRemote{value: nativeFee}(destination, self, amount);
 
     // Execute the specified interchain calls using the remaining gas funds
-    interchainAccountRouter.callRemote{value: msg.value - warpFee}(
+    interchainAccountRouter.callRemote{value: msg.value - nativeFee}(
         destination,
         calls
     );

--- a/docs/guides/warp-routes/evm/transfer-and-call-pattern.mdx
+++ b/docs/guides/warp-routes/evm/transfer-and-call-pattern.mdx
@@ -82,16 +82,29 @@ function transferAndCall(
     CallLib.Call[] calldata calls // Array of calls to execute on the destination chain
 ) external payable {
 
-    // Transfer the specified amount of tokens from the sender to this contract
-    asset.transferFrom(msg.sender, address(this), amount);
-
     // Get the interchain account address for the contract on the destination chain
     bytes32 self = interchainAccountRouter
         .getRemoteInterchainAccount(destination, address(this))
         .addressToBytes32();
 
-    // Quote the gas fee for the HWR payment
-    uint256 warpFee = warpRoute.quoteGasPayment(destination);
+    // Quote the fees for the warp route transfer
+    Quote[] memory quotes = warpRoute.quoteTransferRemote(
+        destination,
+        self,
+        amount
+    );
+
+    // Extract the native mailbox dispatch fee (index 0)
+    uint256 warpFee = quotes[0].amount;
+
+    // Extract the total token amount including internal fees (index 1)
+    uint256 totalTokenAmount = quotes[1].amount;
+
+    // Transfer the total token amount from the sender to this contract
+    asset.transferFrom(msg.sender, address(this), totalTokenAmount);
+
+    // Approve the warp route to spend the tokens
+    asset.approve(address(warpRoute), totalTokenAmount);
 
     // Initiate the HWR transfer to send tokens cross-chain
     warpRoute.transferRemote{value: warpFee}(destination, self, amount);

--- a/docs/protocol/core/fees.mdx
+++ b/docs/protocol/core/fees.mdx
@@ -45,4 +45,4 @@ Read more about transfer fees and calculations:
 
 When using Warp Routes to bridge tokens, there may be additional application fees denominated in the token being bridged.
 
-See [Warp Route Fees](docs/applications/warp-routes/interface) for more details
+See [Warp Route Fees](/docs/applications/warp-routes/interface) for more details

--- a/docs/protocol/core/fees.mdx
+++ b/docs/protocol/core/fees.mdx
@@ -8,7 +8,7 @@ description: "Understanding origin and interchain fees for Hyperlane cross-chain
 When sending a cross-chain message with Hyperlane GMP, two fees are paid:
 
 1. **Origin Fee** – transaction fee on the origin chain (charged by the blockchain)
-2. [**Interchain Fee**](/docs/protocol/core/interchain-gas-payment) – charged to cover destination chain transaction fees
+2. [**Interchain Fee**](/docs/protocol/core/interchain-gas-payment) – charged by relayer to cover destination chain transaction fees
 
 This fee structure ensures that:
 
@@ -40,3 +40,9 @@ Read more about transfer fees and calculations:
 - [Post Dispatch Hooks](/docs/protocol/core/post-dispatch-hooks-overview) - Framework for executing actions after message dispatch
 
 </Note>
+
+## Warp Route Fees
+
+When using Warp Routes to bridge tokens, there may be additional application fees denominated in the token being bridged.
+
+See [Warp Route Fees](docs/applications/warp-routes/interface) for more details

--- a/docs/protocol/core/fees.mdx
+++ b/docs/protocol/core/fees.mdx
@@ -1,16 +1,14 @@
 ---
-title: "Transfer Fees"
+title: "Dispatch Fees"
 description: "Understanding origin and interchain fees for Hyperlane cross-chain transfers"
 ---
 
 ## Fee Estimation
 
-When sending a cross-chain transfer with Hyperlane GMP, two fees are required:
+When sending a cross-chain message with Hyperlane GMP, two fees are paid:
 
-1. **Origin Fee** – gas to submit the transaction on the origin chain
-2. [**Interchain Fee**](/docs/protocol/core/interchain-gas-payment) – gas to deliver and execute the message on the destination chain, including the relayer fee
-
-Both are paid upfront on the origin chain to the specified IGP.
+1. **Origin Fee** – transaction fee on the origin chain (charged by the blockchain)
+2. [**Interchain Fee**](/docs/protocol/core/interchain-gas-payment) – charged to cover destination chain transaction fees
 
 This fee structure ensures that:
 
@@ -20,7 +18,7 @@ This fee structure ensures that:
 
 #### Fee Token Considerations
 
-When sending cross-chain transfers, the fee tokens vary by origin chain type and IGP:
+When sending cross-chain messages, the fee tokens vary by origin chain type and IGP:
 
 1. **EVM Chains**
 

--- a/docs/reference/developer-tools/typescript-sdk/transfer-fee-calculation.mdx
+++ b/docs/reference/developer-tools/typescript-sdk/transfer-fee-calculation.mdx
@@ -55,3 +55,32 @@ const txs = await warpCore.getTransferRemoteTxs({
 ## How It Works
 
 Under the hood, the SDK uses [`Mailbox.quoteDispatch()`](/docs/reference/messaging/send#quote-dispatch) to compute the interchain fee. This is the same value that must be passed to `dispatch`.
+
+## Contract-Level Fee Quoting
+
+<Info>
+  New in version 10.0.0: Warp route contracts now expose a standardized `quoteTransferRemote` function for on-chain fee quoting.
+</Info>
+
+For contracts interacting directly with warp routes (without using the TypeScript SDK), you can quote fees on-chain using the `quoteTransferRemote` function:
+
+```solidity
+// Quote fees for a warp route transfer
+Quote[] memory quotes = warpRoute.quoteTransferRemote(
+    destinationDomain,
+    recipientAddress,
+    amount  // Exact amount recipient will receive
+);
+
+// quotes[0]: Native mailbox dispatch fee (token: address(0))
+// quotes[1]: Total token amount including internal fees
+// quotes[2]: External bridge fees (if any, else 0)
+```
+
+The quotes array always contains exactly 3 elements:
+
+1. **Native Fee** (`quotes[0]`): Must be sent as `msg.value` to `transferRemote`
+2. **Token Amount** (`quotes[1]`): Total tokens to approve/send, including fees
+3. **External Fee** (`quotes[2]`): Additional bridge fees (already included in `quotes[1]`)
+
+See the [HWR Interface](/docs/applications/warp-routes/interface#fee-quoting-interface) for detailed documentation and examples.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an on-chain fee-quoting API that returns structured native vs token fee breakdowns and exact amount-out semantics for remote transfers.

* **Documentation**
  * Renamed fee guidance to "Dispatch Fees" and expanded rationale, upfront-payment implications, and execution prerequisites.
  * Updated Warp Route transfer guidance with concrete fee-handling patterns, examples, and a warning to always query fees immediately before transfer.
  * Added SDK and contract-level fee-quoting docs and usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->