### PR TITLE
chore: migrate community chat from Discord to GitHub Discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ This documentation is open source and contributions are welcome. To contribute:
 
 For questions about Hyperlane:
 
-- [Discord Community](https://discord.gg/hyperlane)
 - [GitHub Discussions](https://github.com/hyperlane-xyz/hyperlane-monorepo/discussions)
 
 ## Troubleshooting

--- a/docs.json
+++ b/docs.json
@@ -368,8 +368,7 @@
   "footer": {
     "socials": {
       "x": "https://x.com/hyperlane",
-      "github": "https://github.com/hyperlane-xyz",
-      "discord": "https://discord.com/invite/hyperlane"
+      "github": "https://github.com/hyperlane-xyz"
     },
     "links": [
       {
@@ -393,8 +392,8 @@
         "header": "Community",
         "items": [
           {
-            "label": "Discord",
-            "href": "https://discord.gg/hyperlane"
+            "label": "GitHub Discussions",
+            "href": "https://github.com/hyperlane-xyz/hyperlane-monorepo/discussions"
           },
           {
             "label": "Twitter",

--- a/docs/alt-vm-implementations/overview.mdx
+++ b/docs/alt-vm-implementations/overview.mdx
@@ -6,7 +6,8 @@ While our public documentation currently focuses on EVM compatibility, we offer 
 
 <Note>
   If you're excited about building on top of these or bringing Hyperlane to
-  other new ecosystems, reach out on [GitHub Discussions](https://github.com/hyperlane-xyz/hyperlane-monorepo/discussions)!
+  other new ecosystems, reach out on [GitHub
+  Discussions](https://github.com/hyperlane-xyz/hyperlane-monorepo/discussions)!
 </Note>
 
 ## Cosmos

--- a/docs/alt-vm-implementations/overview.mdx
+++ b/docs/alt-vm-implementations/overview.mdx
@@ -6,8 +6,7 @@ While our public documentation currently focuses on EVM compatibility, we offer 
 
 <Note>
   If you're excited about building on top of these or bringing Hyperlane to
-  other new ecosystems, reach out on [our
-  Discord](https://discord.gg/hyperlane)!
+  other new ecosystems, reach out on [GitHub Discussions](https://github.com/hyperlane-xyz/hyperlane-monorepo/discussions)!
 </Note>
 
 ## Cosmos

--- a/docs/get-started-building.mdx
+++ b/docs/get-started-building.mdx
@@ -134,5 +134,7 @@ Bridge your tokens using Hyperlane's messaging infrastructure.
 ## Need Help?
 
 <Note>
-  Join [GitHub Discussions](https://github.com/hyperlane-xyz/hyperlane-monorepo/discussions) for support!
+  Join [GitHub
+  Discussions](https://github.com/hyperlane-xyz/hyperlane-monorepo/discussions)
+  for support!
 </Note>

--- a/docs/get-started-building.mdx
+++ b/docs/get-started-building.mdx
@@ -134,5 +134,5 @@ Bridge your tokens using Hyperlane's messaging infrastructure.
 ## Need Help?
 
 <Note>
-  Join our [Discord community](https://discord.gg/hyperlane) for support!
+  Join [GitHub Discussions](https://github.com/hyperlane-xyz/hyperlane-monorepo/discussions) for support!
 </Note>

--- a/docs/guides/chains/deploy-hyperlane.mdx
+++ b/docs/guides/chains/deploy-hyperlane.mdx
@@ -8,7 +8,7 @@ description: "Step-by-step guide on how to connect your chain with Hyperlane"
 - This guide is for **EVM-compatible** chains only.
 - It will walk you through deploying Hyperlane to your new chain as quickly as possible for testing, not production. This includes the core Mailbox and ISM contracts as well as Hyperlane Warp Route contracts for asset bridging.
 - To see which chains are already supported, visit the [Registry](https://github.com/hyperlane-xyz/hyperlane-registry/tree/main/chains).
-- If you need any help, reach out on #developers on Discord or [get in touch](https://forms.gle/KyRTaWvo4XNmNvrq6).
+- If you need any help, reach out on [GitHub Discussions](https://github.com/hyperlane-xyz/hyperlane-monorepo/discussions) or [get in touch](https://forms.gle/KyRTaWvo4XNmNvrq6).
 
 </Note>
 

--- a/docs/guides/quickstart/deploy-warp-route.mdx
+++ b/docs/guides/quickstart/deploy-warp-route.mdx
@@ -39,9 +39,7 @@ This command provides a walkthrough, prompting you for configuration choices dir
 - If your config looks correct, you can now skip to [Step 2:
   Deployment](#2-deployment). Or see below for details on how to define your
   config manually.
-- If you need any help setting up a token bridge, reach out
-  on #developers on Discord or [get in
-  touch](https://forms.gle/KyRTaWvo4XNmNvrq6).
+- If you need any help setting up a token bridge, reach out on [GitHub Discussions](https://github.com/hyperlane-xyz/hyperlane-monorepo/discussions) or [get in touch](https://forms.gle/KyRTaWvo4XNmNvrq6).
 
 </Info>
 

--- a/docs/guides/quickstart/deploy-warp-route.mdx
+++ b/docs/guides/quickstart/deploy-warp-route.mdx
@@ -48,13 +48,11 @@ This command provides a walkthrough, prompting you for configuration choices dir
 Your config consists of a map of chain names to deployment configs. Each config sets details about the token for which you are creating a HWR.
 
 - **type**:
-
   - Set this to `collateral` to create a basic HWR for an ERC20/ERC721 token
   - Set this to `collateralVault` to create a yield-bearing HWR for an ERC20 token that deposits into an existing ERC4626 vault
   - Set this to `native` to create a HWR for a native token (e.g. ether)
 
 - **address:**
-
   - If using `collateral`, the address of the ERC20/ERC721 contract for which to create a route
   - If using `collateralVault`, the address of the existing ERC4626 vault to deposit collateral into
 

--- a/docs/guides/warp-routes/svm/svm-warp-route-guide.mdx
+++ b/docs/guides/warp-routes/svm/svm-warp-route-guide.mdx
@@ -182,8 +182,7 @@ Deploying a HWR requires there to be a core Hyperlane deployment that is connect
   soon as possible, it's not as reliable as we would hope. Please get in touch
   through a [GitHub
   issue](https://github.com/hyperlane-xyz/hyperlane-monorepo/issues) or via the
-  `developers` channel on [Discord](https://discord.gg/2BYk6kV7) if you run into
-  issues.
+  [GitHub Discussions](https://github.com/hyperlane-xyz/hyperlane-monorepo/discussions) if you run into issues.
 </Info>
 
 #### Troubleshooting tips

--- a/docs/guides/warp-routes/svm/svm-warp-route-guide.mdx
+++ b/docs/guides/warp-routes/svm/svm-warp-route-guide.mdx
@@ -140,7 +140,6 @@ Deploying a HWR requires there to be a core Hyperlane deployment that is connect
 ### Step 4: Deploy the HWR
 
 1. Fund the new keypair on both networks the HWR is being deployed to.
-
    - The public key should be the same across SVM networks, but double check with the wallets recommended by each chain, by loading the private key into them.
 
    - The funding should be enough to cover rent for all accounts related to the HWR, pay for transaction fees, and fund the [ATA](https://www.alchemy.com/overviews/associated-token-account) payer accounts (more on this below). For reference, the observed rent from one HWR account is `2.35 SOL` on Solana and `0.025 ETH` on Eclipse, so it's a good idea to fund the key with at least `5 SOL` / `0.05 ETH`.
@@ -182,13 +181,14 @@ Deploying a HWR requires there to be a core Hyperlane deployment that is connect
   soon as possible, it's not as reliable as we would hope. Please get in touch
   through a [GitHub
   issue](https://github.com/hyperlane-xyz/hyperlane-monorepo/issues) or via the
-  [GitHub Discussions](https://github.com/hyperlane-xyz/hyperlane-monorepo/discussions) if you run into issues.
+  [GitHub
+  Discussions](https://github.com/hyperlane-xyz/hyperlane-monorepo/discussions)
+  if you run into issues.
 </Info>
 
 #### Troubleshooting tips
 
 - The script is unlikely to work from the first try due to network congestion and program size, but the script should be idempotent and skip contracts that were already deployed/initialized.
-
   - Errors like `Error: 11 write transactions failed` or `Error: Custom: Invalid blockhash` can always be retried by re-running the command. If retriable errors persist, consider increasing the compute unit price [here](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/44e0ff0733baf0da4d2b0304915f5f6cce92ffc7/rust/sealevel/client/src/cmd_utils.rs#L76).
 
   - For other error types, you may need to close the buffers and programs of your deployer key and redeploy everything from scratch. To display buffers and programs and close them one by one, follow the commands below. Closing programs also helps recover their rent deposit.

--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -18,7 +18,6 @@ Hyperlane is a permissionless interoperability protocol for cross-chain communic
 Get started with Hyperlane by exploring deployment guides & key features:
 
 - **[Bridge any token with Hyperlane Warp Routes (HWR)](/docs/guides/quickstart/deploy-warp-route)**: HWRs let you deploy a custom token bridge, enabling any native or `ERC20` token to be transferred across chains.
-
   - For **EVM-based chains**, use the **[EVM HWR Guide](/docs/guides/quickstart/deploy-warp-route)**.
   - For **Solana Virtual Machine (SVM) chains**, see the **[SVM HWR Guide](/docs/guides/warp-routes/svm/svm-warp-route-guide)**.
   - For **Cosmos SDK-based chains**, use the **[Cosmos SDK Module](/docs/alt-vm-implementations/cosmos-sdk)**.

--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -30,4 +30,4 @@ Get started with Hyperlane by exploring deployment guides & key features:
 
 - **[Deploy Hyperlane to your chain](/docs/guides/chains/deploy-hyperlane)**: Set up Hyperlane on a new chain.
 
-- **Join our Ecosystem:** [Discord](https://discord.com/invite/hyperlane) | [Twitter](https://x.com/hyperlane)
+- **Join our Ecosystem:** [GitHub Discussions](https://github.com/hyperlane-xyz/hyperlane-monorepo/discussions) | [Twitter](https://x.com/hyperlane)

--- a/docs/reference/explorer/explorer-debugging.mdx
+++ b/docs/reference/explorer/explorer-debugging.mdx
@@ -39,7 +39,8 @@ If the gas estimation of the message recipient's `IMessageRecipient.handle()` fu
 
 <Info>
   If you have a use case which is not accommodated by this behavior, **please
-  reach out** on [GitHub Discussions](https://github.com/hyperlane-xyz/hyperlane-monorepo/discussions).
+  reach out** on [GitHub
+  Discussions](https://github.com/hyperlane-xyz/hyperlane-monorepo/discussions).
 </Info>
 
 ### Underfunded

--- a/docs/reference/explorer/explorer-debugging.mdx
+++ b/docs/reference/explorer/explorer-debugging.mdx
@@ -39,7 +39,7 @@ If the gas estimation of the message recipient's `IMessageRecipient.handle()` fu
 
 <Info>
   If you have a use case which is not accommodated by this behavior, **please
-  reach out** [on Discord](https://discord.com/invite/hyperlane).
+  reach out** on [GitHub Discussions](https://github.com/hyperlane-xyz/hyperlane-monorepo/discussions).
 </Info>
 
 ### Underfunded

--- a/docs/resources/faq.mdx
+++ b/docs/resources/faq.mdx
@@ -29,7 +29,7 @@ For inspiration, take a look at some of the pre-built applications built on top 
 - **Interchain Accounts**: Lets users make interchain function calls.
 - **Interchain Queries**: Lets users make interchain view calls.
 
-**I’m a developer. How can my team build with Hyperlane?** If you’re reading this FAQ, you’ve found the docs which is a great place to start. That said, we know that questions arise during implementation, and we’re happy to help you on your way. The Hyperlane community is regularly active in the [Discord](https://discord.gg/hyperlane). Feedback from developers directly influences the product roadmap.
+**I'm a developer. How can my team build with Hyperlane?** If you're reading this FAQ, you've found the docs which is a great place to start. That said, we know that questions arise during implementation, and we're happy to help you on your way. The Hyperlane community is regularly active in [GitHub Discussions](https://github.com/hyperlane-xyz/hyperlane-monorepo/discussions). Feedback from developers directly influences the product roadmap.
 
 ## Technical Questions
 
@@ -96,7 +96,7 @@ Validators use the [`MerkleTreeHook.latestCheckpoint()`](https://github.com/hype
 
 **How can I join the Hyperlane community?**
 
-You can join the [Discord](https://discord.gg/hyperlane) or follow Hyperlane on [Twitter](https://x.com/hyperlane), where you can find a growing community of developers and enthusiasts to chat about the interchain future.
+You can join [GitHub Discussions](https://github.com/hyperlane-xyz/hyperlane-monorepo/discussions) or follow Hyperlane on [Twitter](https://x.com/hyperlane), where you can find a growing community of developers and enthusiasts to chat about the interchain future.
 
 **I'm interested in working on Hyperlane. Where can I see job openings?**
 
@@ -108,4 +108,4 @@ You can make a PR to edit this documentation directly via the [docs repo](https:
 
 **Where can I get support or ask questions about Hyperlane?**
 
-You can get support and ask questions on our [Hyperlane Discord](https://discord.com/invite/hyperlane), where the community and team are active and ready to assist.
+You can get support and ask questions on [GitHub Discussions](https://github.com/hyperlane-xyz/hyperlane-monorepo/discussions), where the community and team are active and ready to assist.

--- a/docs/resources/message-debugging.mdx
+++ b/docs/resources/message-debugging.mdx
@@ -129,6 +129,6 @@ HYP_KEY=0xffff00000000000000000000000000000000000000000000000000000000ffff hyper
 </Accordion>
 
 <Accordion title="I still need help with my message not being delivered">
-  If the above steps haven't helped, you can create a new post in
-  [GitHub Discussions](https://github.com/hyperlane-xyz/hyperlane-monorepo/discussions).
+  If the above steps haven't helped, you can create a new post in [GitHub
+  Discussions](https://github.com/hyperlane-xyz/hyperlane-monorepo/discussions).
 </Accordion>

--- a/docs/resources/message-debugging.mdx
+++ b/docs/resources/message-debugging.mdx
@@ -129,7 +129,6 @@ HYP_KEY=0xffff00000000000000000000000000000000000000000000000000000000ffff hyper
 </Accordion>
 
 <Accordion title="I still need help with my message not being delivered">
-  If the above steps haven't helped, you can join our
-  [Discord](https://discord.com/invite/hyperlane) and create a new post in the
-  **#support-forum** channel.
+  If the above steps haven't helped, you can create a new post in
+  [GitHub Discussions](https://github.com/hyperlane-xyz/hyperlane-monorepo/discussions).
 </Accordion>


### PR DESCRIPTION
## Summary
Updates all references from Discord to GitHub Discussions as the primary community channel.

## Changes
- Replaced Discord links/mentions with GitHub Discussions links
- Updated documentation and READMEs to point to the new community forum

## Context
We're consolidating community support and discussions to GitHub Discussions for better discoverability and support. 