### PR TITLE
docs: add deprecated chains page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -46,7 +46,8 @@
                     ]
                   },
                   "docs/reference/domains",
-                  "docs/reference/registries"
+                  "docs/reference/registries",
+                  "docs/reference/deprecated-chains"
                 ]
               },
               "docs/ecosystem"

--- a/docs/reference/deprecated-chains.mdx
+++ b/docs/reference/deprecated-chains.mdx
@@ -35,5 +35,6 @@ Abacus Works is winding down its [Relayer](/docs/protocol/agents/relayer) and [V
 | Tangle        | 5845       | 5845       | April 25, 2026 |
 | Zero Network  | 543210     | 543210     | April 25, 2026 |
 | Zora          | 7777777    | 7777777    | April 25, 2026 |
-| MilkyWay      | 1835625579 | 1835625579 | May 8, 2026    |
-| Polynomial    | 8008       | 1000008008 | May 8, 2026    |
+| MilkyWay      | 1835625579 | 1835625579 | May 8, 2026     |
+| Polynomial    | 8008       | 1000008008 | May 8, 2026     |
+| Zircuit       | 48900      | 48900      | June 20, 2026   |

--- a/docs/reference/deprecated-chains.mdx
+++ b/docs/reference/deprecated-chains.mdx
@@ -35,6 +35,6 @@ Abacus Works is winding down its [Relayer](/docs/protocol/agents/relayer) and [V
 | Tangle        | 5845       | 5845       | April 25, 2026 |
 | Zero Network  | 543210     | 543210     | April 25, 2026 |
 | Zora          | 7777777    | 7777777    | April 25, 2026 |
-| MilkyWay      | 1835625579 | 1835625579 | May 8, 2026     |
-| Polynomial    | 8008       | 1000008008 | May 8, 2026     |
+| MilkyWay      | 1835625579 | 1835625579 | April 25, 2026  |
+| Polynomial    | 8008       | 1000008008 | April 25, 2026  |
 | Zircuit       | 48900      | 48900      | June 20, 2026   |

--- a/docs/reference/deprecated-chains.mdx
+++ b/docs/reference/deprecated-chains.mdx
@@ -1,0 +1,39 @@
+---
+title: Deprecated Chains
+description: Chains being removed from Abacus Works agent operations
+---
+
+Abacus Works is winding down its [Relayer](/docs/protocol/agents/relayer) and [Validator](/docs/protocol/agents/validators) operations for the chains listed below.
+
+**What this means:**
+- **Relayer** — Once removed, messages will not be automatically delivered. The community can [run their own Relayer](/docs/operate/relayer/run-relayer) to keep message delivery operational.
+- **Validators** — Abacus Works will wind down its Validators for these chains. Chain teams should [run their own Validator](/docs/operate/validators/run-validators) and reach out to the Abacus Works team to update the default ISM.
+
+<Warning>
+  If you're building on any of these chains, plan your migration before the removal date. To take over agent operations, refer to the [Validator](/docs/operate/validators/run-validators) and [Relayer](/docs/operate/relayer/run-relayer) guides.
+</Warning>
+
+| Chain         | Chain ID   | Domain ID  | Removal Date   |
+|---------------|------------|------------|----------------|
+| Arbitrum Nova | 42170      | 42170      | April 25, 2026 |
+| Aurora        | 1313161554 | 1313161554 | April 25, 2026 |
+| B² Network    | 223        | 223        | April 25, 2026 |
+| B3            | 8333       | 8333       | April 25, 2026 |
+| Degenchain    | 666666666  | 666666666  | April 25, 2026 |
+| Dogechain     | 2000       | 2000       | April 25, 2026 |
+| Everclear     | 25327      | 25327      | April 25, 2026 |
+| Fantom        | 250        | 250        | April 25, 2026 |
+| Fluence       | 9999999    | 9999999    | April 25, 2026 |
+| Harmony       | 1666600000 | 1666600000 | April 25, 2026 |
+| Merlin        | 4200       | 4200       | April 25, 2026 |
+| Molten        | 360        | 360        | April 25, 2026 |
+| Moonbeam      | 1284       | 1284       | April 25, 2026 |
+| Polygon zkEVM | 1101       | 1101       | April 25, 2026 |
+| Scroll        | 534352     | 534352     | April 25, 2026 |
+| Story         | 1514       | 1514       | April 25, 2026 |
+| Superposition | 55244      | 1000055244 | April 25, 2026 |
+| Tangle        | 5845       | 5845       | April 25, 2026 |
+| Zero Network  | 543210     | 543210     | April 25, 2026 |
+| Zora          | 7777777    | 7777777    | April 25, 2026 |
+| MilkyWay      | 1835625579 | 1835625579 | May 8, 2026    |
+| Polynomial    | 8008       | 1000008008 | May 8, 2026    |

--- a/docs/reference/deprecated-chains.mdx
+++ b/docs/reference/deprecated-chains.mdx
@@ -7,34 +7,36 @@ Abacus Works is winding down its [Relayer](/docs/protocol/agents/relayer) and [V
 
 **What this means:**
 - **Relayer** — Once removed, messages will not be automatically delivered. The community can [run their own Relayer](/docs/operate/relayer/run-relayer) to keep message delivery operational.
-- **Validators** — Abacus Works will wind down its Validators for these chains. Chain teams should [run their own Validator](/docs/operate/validators/run-validators) and reach out to the Abacus Works team to update the default ISM.
+- **Validators** — Abacus Works will wind down its Validators for these chains. Chain teams should [run their own Validator](/docs/operate/validators/run-validators) and [reach out to the Abacus Works team](https://github.com/hyperlane-xyz/hyperlane-monorepo/discussions) to update the [default ISM](/docs/reference/addresses/validators/mainnet-default-ism-validators).
 
 <Warning>
-  If you're building on any of these chains, plan your migration before the removal date. To take over agent operations, refer to the [Validator](/docs/operate/validators/run-validators) and [Relayer](/docs/operate/relayer/run-relayer) guides.
+  If you're building on any of these chains, plan your migration before the last supported date. To take over agent operations, refer to the [Validator](/docs/operate/validators/run-validators) and [Relayer](/docs/operate/relayer/run-relayer) guides.
 </Warning>
 
-| Chain         | Chain ID   | Domain ID  | Removal Date   |
-|---------------|------------|------------|----------------|
-| Arbitrum Nova | 42170      | 42170      | April 25, 2026 |
-| Aurora        | 1313161554 | 1313161554 | April 25, 2026 |
-| B² Network    | 223        | 223        | April 25, 2026 |
-| B3            | 8333       | 8333       | April 25, 2026 |
-| Degenchain    | 666666666  | 666666666  | April 25, 2026 |
-| Dogechain     | 2000       | 2000       | April 25, 2026 |
-| Everclear     | 25327      | 25327      | April 25, 2026 |
-| Fantom        | 250        | 250        | April 25, 2026 |
-| Fluence       | 9999999    | 9999999    | April 25, 2026 |
-| Harmony       | 1666600000 | 1666600000 | April 25, 2026 |
-| Merlin        | 4200       | 4200       | April 25, 2026 |
-| Molten        | 360        | 360        | April 25, 2026 |
-| Moonbeam      | 1284       | 1284       | April 25, 2026 |
-| Polygon zkEVM | 1101       | 1101       | April 25, 2026 |
-| Scroll        | 534352     | 534352     | April 25, 2026 |
-| Story         | 1514       | 1514       | April 25, 2026 |
-| Superposition | 55244      | 1000055244 | April 25, 2026 |
-| Tangle        | 5845       | 5845       | April 25, 2026 |
-| Zero Network  | 543210     | 543210     | April 25, 2026 |
-| Zora          | 7777777    | 7777777    | April 25, 2026 |
-| MilkyWay      | 1835625579 | 1835625579 | April 25, 2026  |
-| Polynomial    | 8008       | 1000008008 | April 25, 2026  |
-| Zircuit       | 48900      | 48900      | June 20, 2026   |
+| Chain         | Domain ID  | Chain ID   | Last Supported Date |
+|---------------|------------|------------|---------------------|
+| Arbitrum Nova | 42170      | 42170      | May 10, 2026        |
+| Aurora        | 1313161554 | 1313161554 | May 10, 2026        |
+| B² Network    | 223        | 223        | May 10, 2026        |
+| B3            | 8333       | 8333       | May 10, 2026        |
+| Degen         | 666666666  | 666666666  | May 10, 2026        |
+| Dogechain     | 2000       | 2000       | May 10, 2026        |
+| Everclear     | 25327      | 25327      | May 10, 2026        |
+| Fantom Opera  | 250        | 250        | May 10, 2026        |
+| Fluence       | 9999999    | 9999999    | May 10, 2026        |
+| Harmony One   | 1666600000 | 1666600000 | May 10, 2026        |
+| Merlin        | 4200       | 4200       | May 10, 2026        |
+| MilkyWay      | 1835625579 | milkyway   | May 10, 2026        |
+| Molten        | 360        | 360        | May 10, 2026        |
+| Moonbeam      | 1284       | 1284       | May 10, 2026        |
+| Polygon zkEVM | 1101       | 1101       | May 10, 2026        |
+| Polynomial    | 1000008008 | 8008       | May 10, 2026        |
+| Scroll        | 534352     | 534352     | May 10, 2026        |
+| Story Mainnet | 1514       | 1514       | May 10, 2026        |
+| Superposition | 1000055244 | 55244      | May 10, 2026        |
+| Tangle        | 5845       | 5845       | May 10, 2026        |
+| Zero Network  | 543210     | 543210     | May 10, 2026        |
+| Zora          | 7777777    | 7777777    | May 10, 2026        |
+| Zircuit       | 48900      | 48900      | June 20, 2026       |
+
+*Chain and domain IDs sourced from the [Hyperlane Registry](https://github.com/hyperlane-xyz/hyperlane-registry).*

--- a/docs/reference/deprecated-chains.mdx
+++ b/docs/reference/deprecated-chains.mdx
@@ -7,7 +7,7 @@ Abacus Works is winding down its [Relayer](/docs/protocol/agents/relayer) and [V
 
 **What this means:**
 - **Relayer** — Once removed, messages will not be automatically delivered. The community can [run their own Relayer](/docs/operate/relayer/run-relayer) to keep message delivery operational.
-- **Validators** — Abacus Works will wind down its Validators for these chains. Chain teams should [run their own Validator](/docs/operate/validators/run-validators) and [reach out to the Abacus Works team](https://github.com/hyperlane-xyz/hyperlane-monorepo/discussions) to update the [default ISM](/docs/reference/addresses/validators/mainnet-default-ism-validators).
+- **Validators** — Abacus Works will wind down its Validators for these chains. Chain teams and ecosystem partners can [run their own Validator](/docs/operate/validators/run-validators) and [reach out to the Abacus Works team](https://github.com/hyperlane-xyz/hyperlane-monorepo/discussions) to update the [default ISM](/docs/reference/addresses/validators/mainnet-default-ism-validators).
 
 <Warning>
   If you're building on any of these chains, plan your migration before the last supported date. To take over agent operations, refer to the [Validator](/docs/operate/validators/run-validators) and [Relayer](/docs/operate/relayer/run-relayer) guides.

--- a/docs/reference/deprecated-chains.mdx
+++ b/docs/reference/deprecated-chains.mdx
@@ -10,7 +10,7 @@ Abacus Works is winding down its [Relayer](/docs/protocol/agents/relayer) and [V
 - **Validators** — Abacus Works will wind down its Validators for these chains. Chain teams and ecosystem partners can [run their own Validator](/docs/operate/validators/run-validators) and [reach out to the Abacus Works team](https://github.com/hyperlane-xyz/hyperlane-monorepo/discussions) to update the [default ISM](/docs/reference/addresses/validators/mainnet-default-ism-validators).
 
 <Warning>
-  If you're building on any of these chains, plan your migration before the last supported date. To take over agent operations, refer to the [Validator](/docs/operate/validators/run-validators) and [Relayer](/docs/operate/relayer/run-relayer) guides.
+  If you're building on any of these chains, plan your migration before the last supported date. After the listed date, Abacus Works will no longer operate agents for that chain. To take over agent operations, refer to the [Validator](/docs/operate/validators/run-validators) and [Relayer](/docs/operate/relayer/run-relayer) guides.
 </Warning>
 
 | Chain         | Domain ID  | Chain ID   | Last Supported Date |


### PR DESCRIPTION
## Summary

- Adds a new `Deprecated Chains` page under the Deployments nav group
- Lists 23 chains being removed from Abacus Works' Relayer and Validator operations
- Includes chain IDs, domain IDs, and removal dates (April 25, May 8, June 20)
- Explains the impact on relaying and the default ISM validator set

## Test plan
- [ ] Check page renders correctly on Mintlify
- [ ] Verify all links (Relayer, Validator, default ISM guides) resolve correctly
- [ ] Confirm chain IDs and domain IDs are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)