### PR TITLE
feat: improved yield route docs and other fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Hyperlane v4 Documentation is a Mintlify-powered documentation site for the Hype
 mint dev
 
 # Check for broken links
-mintlify broken-links
+mint broken-links
 ```
 
 ## Architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Hyperlane v4 Documentation is a Mintlify-powered documentation site for the Hype
 
 ```bash
 # Local development
-mintlify dev
+mint dev
 
 # Check for broken links
 mintlify broken-links

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ This documentation provides comprehensive guides, API references, and examples f
 Follow the Mintlify setup guide for the most updated instructions:  
 [Mintlify Installation Docs](https://www.mintlify.com/docs/installation)
 
+Then start the local dev server:
+
 ```bash
 mint dev
 ```

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ This documentation provides comprehensive guides, API references, and examples f
 Follow the Mintlify setup guide for the most updated instructions:  
 [Mintlify Installation Docs](https://www.mintlify.com/docs/installation)
 
+```bash
+mint dev
+```
+
 ## Contributing
 
 This documentation is open source and contributions are welcome. To contribute:

--- a/docs.json
+++ b/docs.json
@@ -72,7 +72,8 @@
                   "docs/applications/warp-routes/types",
                   "docs/applications/warp-routes/example-usage",
                   "docs/applications/warp-routes/multi-collateral-warp-routes",
-                  "docs/guides/warp-routes/evm/multi-collateral-warp-routes-rebalancing"
+                  "docs/guides/warp-routes/evm/multi-collateral-warp-routes-rebalancing",
+                  "docs/applications/warp-routes/yield-routes"
                 ]
               },
               {

--- a/docs/applications/warp-routes/yield-routes.mdx
+++ b/docs/applications/warp-routes/yield-routes.mdx
@@ -2,7 +2,7 @@
 title: "Yield Routes"
 ---
 
-A **yield route** is a [Hyperlane Warp Route](/docs/applications/warp-routes/overview) variant that puts bridged collateral to work. While the assets sit locked on the source chain, they are deposited into an [ERC-4626 vault](https://ethereum.org/en/developers/docs/standards/tokens/erc-4626/) that earns yield. Yield routes use the ERC-4626 standard, so any vault that implements it can be used as-is.
+A **yield route** is a [Hyperlane Warp Route](/docs/applications/warp-routes/overview) variant that puts bridged collateral to work. While the assets sit locked on the origin chain, they are deposited into an [ERC-4626 vault](https://ethereum.org/en/developers/docs/standards/tokens/erc-4626/) that earns yield. Yield routes use the ERC-4626 standard, so any compliant vault can be used without modification.
 
 <Note>
   **ERC-4626** is the Ethereum standard for tokenized yield-bearing vaults. When
@@ -13,7 +13,7 @@ A **yield route** is a [Hyperlane Warp Route](/docs/applications/warp-routes/ove
 
 ## Why Yield Routes
 
-Bridged assets typically sit locked in a collateral contract on the source chain. A yield route deposits that collateral into an ERC-4626 vault — such as one provided by Aave or Morpho — so it earns yield while the bridge experience for the holder stays the same.
+Bridged assets typically sit locked in a collateral contract on the origin chain. A yield route deposits that collateral into an ERC-4626 vault — such as one provided by Aave or Morpho — so it earns yield while the bridge experience for the holder stays the same.
 
 <CardGroup cols={1}>
   <Card title="Put bridged assets to work" icon="chart-line">
@@ -84,21 +84,11 @@ flowchart LR
     YR -->|Returns USDC| R((Recipient))
 ```
 
-## Vault integration
+## Vault Integration
 
-The route deployer specifies the vault address at deploy time. From then on, the yield route calls the standard ERC-4626 methods (`deposit`, `withdraw`, `previewDeposit`, `convertToAssets`, `convertToShares`) on the vault. The vault itself is not modified or redeployed.
+The route deployer specifies the vault address at deploy time. From then on, the yield route calls the standard ERC-4626 methods (`deposit`, `withdraw`, `previewDeposit`, `convertToAssets`, `convertToShares`) on the vault. The vault itself does not need any Hyperlane-specific implementation.
 
-The vault must:
-
-- Implement the ERC-4626 standard without modifications
-- Not charge fees on deposit or withdrawal
-- Use a non-rebasing underlying asset
-- Use standard share math (no custom overrides on `previewDeposit`, `convertToAssets`, `convertToShares`)
-
-<Warning>
-  If the vault doesn't meet these requirements, the route can produce incorrect
-  exchange rates or accounting errors.
-</Warning>
+See the [Vault compatibility requirements](/docs/guides/warp-routes/evm/deploy-yield-routes#pre-requisites) in the deploy guide for the specific vault requirements.
 
 ## Deploy a Yield Route
 

--- a/docs/applications/warp-routes/yield-routes.mdx
+++ b/docs/applications/warp-routes/yield-routes.mdx
@@ -1,0 +1,111 @@
+---
+title: "Yield Routes"
+---
+
+A **yield route** is a [Hyperlane Warp Route](/docs/applications/warp-routes/overview) variant that puts bridged collateral to work. While the assets sit locked on the source chain, they are deposited into an [ERC-4626 vault](https://ethereum.org/en/developers/docs/standards/tokens/erc-4626/) that earns yield. Yield routes use the ERC-4626 standard, so any vault that implements it can be used as-is.
+
+<Note>
+  **ERC-4626** is the Ethereum standard for tokenized yield-bearing vaults. When
+  you deposit assets, the vault generates yield through some underlying strategy
+  (lending, staking, real-world assets, etc.), and you receive share tokens
+  representing your stake.
+</Note>
+
+## Why Yield Routes
+
+Bridged assets typically sit locked in a collateral contract on the source chain. A yield route deposits that collateral into an ERC-4626 vault — such as one provided by Aave or Morpho — so it earns yield while the bridge experience for the holder stays the same.
+
+<CardGroup cols={1}>
+  <Card title="Put bridged assets to work" icon="chart-line">
+    A yield route turns idle bridged collateral into a yield-earning position.
+    The deployer — a chain team, an app, a protocol — captures yield on assets
+    that would otherwise be unproductive.
+  </Card>
+  <Card title="A new distribution channel" icon="share-nodes">
+    Yield routes create an automatic deposit channel for ERC-4626 vaults:
+
+    - **Bridge users** become depositors without having to discover the vault.
+    - **Vault providers** gain reach without traditional integration work.
+    - **Route deployers** gain a yield-bearing bridge without building any vault themselves.
+
+  </Card>
+  <Card title="Embedded yield for apps" icon="puzzle-piece">
+    A consumer app or fintech can offer yield-bearing deposits without building
+    any vault infrastructure. The app sits on a chain with a yield route pointed
+    at an ERC-4626 vault; the vault provider handles the yield generation.
+  </Card>
+</CardGroup>
+
+## How It Works
+
+### Components
+
+Each yield route has two core contracts:
+
+| Chain           | Contract                                                                                                                                                                                                                                                                                                               | What it does                                                                                                        |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Origin**      | [`HypERC4626OwnerCollateral`](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/solidity/contracts/token/extensions/HypERC4626OwnerCollateral.sol) or [`HypERC4626Collateral`](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/solidity/contracts/token/extensions/HypERC4626Collateral.sol) | Accepts the deposited collateral and forwards it into an ERC-4626 vault. The vault generates yield.                 |
+| **Destination** | [`HypERC20`](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/solidity/contracts/token/HypERC20.sol) or [`HypERC4626`](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/solidity/contracts/token/extensions/HypERC4626.sol)                                                                  | Mints a synthetic representation of the deposited collateral. Holders on the destination chain hold this synthetic. |
+
+Depending on the type of route, yield is distributed to different parties. The two standard types are **owner-yield**, where yield goes to the route owner (the team that deploys and operates the route), and **user-yield**, where yield goes back to the holders of the synthetic token.
+
+### Example flow
+
+Below is the conceptual flow for bridging in and out of a yield route. For the detailed walkthrough, see the [Deploy Yield Routes](/docs/guides/warp-routes/evm/deploy-yield-routes) guide.
+
+**Bridge in: collateral → vault, synthetic minted**
+
+1. The holder sends collateral (e.g. USDC) to the yield route on the origin chain.
+2. The yield route deposits the collateral into an ERC-4626 vault, where it earns yield.
+3. The yield route dispatches a bridge message via Hyperlane to the destination chain.
+4. The synthetic token contract on the destination chain mints the synthetic to the recipient.
+
+```mermaid
+flowchart LR
+    H((Holder)) -->|Sends USDC| YR["Yield Route<br/>(origin chain)"]
+    YR -->|Auto-deposit| V[ERC-4626 Vault]
+    V -.->|Earns yield| V
+    YR ==>|Bridge message| ST["Synthetic Token<br/>(destination chain)"]
+    ST -->|Mints synthetic| R((Recipient))
+```
+
+**Bridge out: synthetic burned, vault → collateral**
+
+1. The holder burns the synthetic on the destination chain.
+2. The destination synthetic contract dispatches a bridge message back to the origin chain.
+3. The yield route on the origin chain withdraws the collateral from the vault.
+4. The yield route returns the collateral to the recipient.
+
+```mermaid
+flowchart LR
+    H((Holder)) -->|Burns synthetic| ST["Synthetic Token<br/>(destination chain)"]
+    ST ==>|Bridge message| YR["Yield Route<br/>(origin chain)"]
+    V[ERC-4626 Vault] -->|Withdraw + yield| YR
+    YR -->|Returns USDC| R((Recipient))
+```
+
+## Vault integration
+
+The route deployer specifies the vault address at deploy time. From then on, the yield route calls the standard ERC-4626 methods (`deposit`, `withdraw`, `previewDeposit`, `convertToAssets`, `convertToShares`) on the vault. The vault itself is not modified or redeployed.
+
+The vault must:
+
+- Implement the ERC-4626 standard without modifications
+- Not charge fees on deposit or withdrawal
+- Use a non-rebasing underlying asset
+- Use standard share math (no custom overrides on `previewDeposit`, `convertToAssets`, `convertToShares`)
+
+<Warning>
+  If the vault doesn't meet these requirements, the route can produce incorrect
+  exchange rates or accounting errors.
+</Warning>
+
+## Deploy a Yield Route
+
+<Card
+  title="Deploy Yield Routes"
+  icon="rocket"
+  href="/docs/guides/warp-routes/evm/deploy-yield-routes"
+>
+  Step-by-step walkthrough using the Hyperlane CLI.
+</Card>

--- a/docs/applications/warp-routes/yield-routes.mdx
+++ b/docs/applications/warp-routes/yield-routes.mdx
@@ -2,7 +2,7 @@
 title: "Yield Routes"
 ---
 
-A **yield route** is a [Hyperlane Warp Route](/docs/applications/warp-routes/overview) variant that puts bridged collateral to work. While the assets sit locked on the origin chain, they are deposited into an [ERC-4626 vault](https://ethereum.org/en/developers/docs/standards/tokens/erc-4626/) that earns yield — any vault that implements the standard can be used without modification.
+A **yield route** is a [Hyperlane Warp Route](/docs/applications/warp-routes/overview) variant that puts bridged collateral to work. While the assets sit locked on the origin chain, they are deposited into an [ERC-4626 vault](https://ethereum.org/en/developers/docs/standards/tokens/erc-4626/) that earns yield.
 
 <Note>
   **ERC-4626** is the Ethereum standard for tokenized yield-bearing vaults. When
@@ -86,7 +86,7 @@ flowchart LR
 
 ## Vault Integration
 
-The route deployer specifies the vault address at deploy time. From then on, the yield route calls the standard ERC-4626 methods (`deposit`, `withdraw`, `previewDeposit`, `convertToAssets`, `convertToShares`) on the vault. The vault itself does not need any Hyperlane-specific implementation.
+The route deployer specifies the vault address at deploy time. From then on, the yield route calls the standard ERC-4626 methods (`deposit`, `withdraw`, `previewDeposit`, `convertToAssets`, `convertToShares`) on the vault. The vault itself does not need any Hyperlane-specific implementation — any vault that implements the standard can be used without modification.
 
 See the [Vault compatibility requirements](/docs/guides/warp-routes/evm/deploy-yield-routes#pre-requisites) in the deploy guide for the specific vault requirements.
 

--- a/docs/applications/warp-routes/yield-routes.mdx
+++ b/docs/applications/warp-routes/yield-routes.mdx
@@ -2,7 +2,7 @@
 title: "Yield Routes"
 ---
 
-A **yield route** is a [Hyperlane Warp Route](/docs/applications/warp-routes/overview) variant that puts bridged collateral to work. While the assets sit locked on the origin chain, they are deposited into an [ERC-4626 vault](https://ethereum.org/en/developers/docs/standards/tokens/erc-4626/) that earns yield. Yield routes use the ERC-4626 standard, so any compliant vault can be used without modification.
+A **yield route** is a [Hyperlane Warp Route](/docs/applications/warp-routes/overview) variant that puts bridged collateral to work. While the assets sit locked on the origin chain, they are deposited into an [ERC-4626 vault](https://ethereum.org/en/developers/docs/standards/tokens/erc-4626/) that earns yield — any vault that implements the standard can be used without modification.
 
 <Note>
   **ERC-4626** is the Ethereum standard for tokenized yield-bearing vaults. When
@@ -47,7 +47,7 @@ Each yield route has two core contracts:
 | **Origin**      | [`HypERC4626OwnerCollateral`](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/solidity/contracts/token/extensions/HypERC4626OwnerCollateral.sol) or [`HypERC4626Collateral`](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/solidity/contracts/token/extensions/HypERC4626Collateral.sol) | Accepts the deposited collateral and forwards it into an ERC-4626 vault. The vault generates yield.                 |
 | **Destination** | [`HypERC20`](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/solidity/contracts/token/HypERC20.sol) or [`HypERC4626`](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/solidity/contracts/token/extensions/HypERC4626.sol)                                                                  | Mints a synthetic representation of the deposited collateral. Holders on the destination chain hold this synthetic. |
 
-Depending on the type of route, yield is distributed to different parties. The two standard types are **owner-yield**, where yield goes to the route owner (the team that deploys and operates the route), and **user-yield**, where yield goes back to the holders of the synthetic token.
+Depending on the type of route, yield is distributed to different parties. The two standard types are **owner-yield** (`HypERC4626OwnerCollateral`), where yield goes to the route owner (the team that deploys and operates the route), and **user-yield** (`HypERC4626Collateral`), where yield goes back to the holders of the synthetic token.
 
 ### Example flow
 

--- a/docs/guides/warp-routes/evm/deploy-yield-routes.mdx
+++ b/docs/guides/warp-routes/evm/deploy-yield-routes.mdx
@@ -4,36 +4,40 @@ title: "Deploy Yield Routes"
 
 The goal of this guide is to illustrate how you can use Hyperlane Warp Routes (HWR) to create yield-generating bridges, ensuring idle bridged assets are productive by compounding yield over time. Depending on the variant (more details below), yields are distributed to the yield route owner or users.
 
-**If you are a vault provider**, you only need to supply your ERC-4626 vault address on the origin chain. Hyperlane (or your integration partner) handles deploying and operating the route. Share this guide with the party doing the deployment and provide them with your vault address.
+<Note>
+  **If you are a vault provider**, you only need to supply your ERC-4626 vault
+  address on the origin chain. Hyperlane (or your integration partner) handles
+  deploying and operating the route. Share this guide with the party doing the
+  deployment and provide them with your vault address.
+</Note>
 
-## Vault Compatibility
+## Concepts
 
-Your vault must implement the [ERC-4626 standard](https://ethereum.org/en/developers/docs/standards/tokens/erc-4626/) faithfully. Vaults that charge a fee on deposit/withdrawal, use a rebasing underlying asset, or override standard share math may produce incorrect exchange rates or accounting errors. If unsure, verify that `previewDeposit`, `convertToAssets`, and `convertToShares` return values consistent with the standard before integrating.
+- **ERC-4626 Vault**: The Ethereum standard for tokenized yield-bearing vaults. Upon deposit, share tokens are minted representing ownership of the underlying asset.
+- **Yield Route (`EvmHypOwnerCollateral` & `EvmHypSynthetic`)**: The Hyperlane representation of a yield-bearing EVM collateral token. The yield route's vault's deposited asset address is used as the HWR's collateral token.
+  - Two variants exist. In **owner-yield routes** (`EvmHypOwnerCollateral` & `EvmHypSynthetic`), vault yields go to the route owner. In **user-yield routes** (`EvmHypRebaseCollateral` & `EvmHypSyntheticRebase`), vault yields are passed through to holders by automatically increasing each holder's balance of the synthetic token. The underlying mechanics are otherwise the same.
 
 ## Pre-Requisites
 
 To complete the following walkthrough, you should have the following available:
 
 1. An origin and destination network of choice, between which you’d like to deploy the yield route.
-2. The address of an [ERC-4626 vault](https://ethereum.org/en/developers/docs/standards/tokens/erc-4626/) on the origin network from which you want yield to be generated. This vault’s underlying asset will be set as the collateral for the HWR (e.g. if vault is USDC funded, the HWR will also support USDC transfer).
-3. An installed instance of the [Hyperlane CLI](https://docs.hyperlane.xyz/docs/reference/developer-tools/cli) and a wallet private key set as the `HYP_KEY` env var funded on your origin and destination networks.
+2. An installed instance of the [Hyperlane CLI](https://docs.hyperlane.xyz/docs/reference/developer-tools/cli) and a wallet private key set as the `HYP_KEY` env var funded on your origin and destination networks.
+3. The address of an [ERC-4626 vault](https://ethereum.org/en/developers/docs/standards/tokens/erc-4626/) on the origin network from which you want yield to be generated. This vault’s underlying asset will be set as the collateral for the HWR (e.g. if vault is USDC funded, the HWR will also support USDC transfer).
+   <Warning>
+     Your vault must implement the [ERC-4626
+     standard](https://ethereum.org/en/developers/docs/standards/tokens/erc-4626/)
+     without modifications to standard behavior. Vaults that charge a fee on
+     deposit/withdrawal, use a rebasing underlying asset, or override standard
+     share math may produce incorrect exchange rates or accounting errors. If
+     unsure, verify that `previewDeposit`, `convertToAssets`, and
+     `convertToShares` return values consistent with the standard before
+     integrating.
+   </Warning>
 
-## Walkthrough
+## Example Bridging Flow
 
-### Concepts
-
-- **ERC-4626 Vault**: The Ethereum standard for tokenized yield-bearing vaults. Upon deposit, share tokens are minted representing ownership of the underlying asset.
-- **Yield Route (EvmHypOwnerCollateral & EvmHypSynthetic)**: The Hyperlane representation of a yield-bearing EVM collateral token. Note that the yield route’s vault’s deposited asset address is used as the HWRs collateral token.
-  - This specific yield route variant distributes vault yields to the **owner**. There is an alternative setup where yields are distributed to the users (EvmHypCollateral & EvmHypSyntheticRebase). For most of this guide, we will refer to the former variants. The concepts remain the same.
-
-<Info>
-  For the sake of this walkthrough, the “origin” network will refer to the
-  network on which the yield is generated (e.g. Ethereum has a USDC lending
-  vault that has claimable yield. A synthetic USDC is minted on the destination
-  chain called yourchain).
-</Info>
-
-Below is the bridging flow between Ethereum and yourchain
+The following walks through a yield route deployed between Ethereum (the origin chain, holding the ERC-4626 vault) and yourchain (the destination chain, where the synthetic is minted).
 
 **Bridge USDC: Ethereum → yourchain**
 
@@ -57,16 +61,15 @@ flowchart LR
     B ==>|Bridge| C[Ethereum:<br>EvmHypOwnerCollateral]
     D[Ethereum:<br>ERC-4626 Vault] -->|USDC Withdraw from Vault| C
     C -->|Withdraw USDC| F[Ethereum:<br>Alice]
-
 ```
 
 When Alice wants to bridge back to Ethereum, the reverse happens. The yield route will burn her synthetic USDC, withdraw the USDC from the vault on Ethereum, and return her USDC.
 
-### Yield Route Deployment Steps
+## Yield Route Deployment Steps
 
 Using the Hyperlane CLI, deploy a USDC EvmHypOwnerCollateral and EvmHypSynthetic tokens on Ethereum and yourchain, respectively:
 
-#### 1. Run `hyperlane warp init` to generate a HWR config:
+**Step 1. Run `hyperlane warp init` to generate a HWR config:**
 
 1.  Select `yourchain` and `Ethereum` using space, and hit enter.
 2.  For Ethereum, select `collateralVault`, accept the mailbox, and enter the USDC vault address on Ethereum.
@@ -75,14 +78,14 @@ Using the Hyperlane CLI, deploy a USDC EvmHypOwnerCollateral and EvmHypSynthetic
 
     - If you selected `collateralVaultRebase`, you must pair it with a `syntheticRebase`
 
-#### 2. Run `hyperlane warp deploy` to deploy the HWR.
+**Step 2. Run `hyperlane warp deploy` to deploy the HWR.**
 
-### Claiming Yield
+## Claiming Yield
 
 Depending on the yield route variant:
 
 - **`collateralVault` (owner yield)**: Call `HypERC4626OwnerCollateral.sweep()` on the origin chain collateral contract. This sends all accrued yield to the contract owner address set at deployment. There is no fixed cadence — call it as often as desired.
-- **`collateralVaultRebase` (user yield)**: Call `HypERC4626Collateral.rebase(destinationDomain)` on the origin chain collateral contract. This sends an updated exchange rate to the synthetic contract on the destination chain, increasing all user balances proportionally. Again, call frequency is up to the operator.
+- **`collateralVaultRebase` (user yield)**: Call `HypERC4626Collateral.rebase(destinationDomain)` on the origin chain collateral contract, where `destinationDomain` is the Hyperlane [domain ID](/docs/reference/domains) of the chain hosting the `syntheticRebase` contract. This sends an updated exchange rate to the synthetic contract on the destination chain, increasing all user balances proportionally.
 
 <Check>
   🎉 Congrats! You have now created a new yield route with your vault. Bridged
@@ -96,11 +99,30 @@ Depending on the yield route variant:
   becomes under-collateralized.
 </Warning>
 
-## Resources
+## More Resources
 
-For more in-depth details on these steps, follow the [Bridge a Token](/docs/guides/quickstart/deploy-warp-route) guide.
+To learn more about yield routes and the underlying standards:
 
-Check out some additional information, published by the Hyperlane supporting team, Cheese Chain, and the Ethereum Foundation:
-
-- [Hyperlane: Introducing Yield Routes](https://medium.com/hyperlane/introducing-yield-routes-f7e8fd091443)
-- [ERC-4626 Tokenized Vault Standard](https://ethereum.org/en/developers/docs/standards/tokens/erc-4626/)
+<CardGroup cols={3}>
+  <Card
+    title="Bridge a Token"
+    icon="rocket"
+    href="/docs/guides/quickstart/deploy-warp-route"
+  >
+    In-depth walkthrough of the underlying warp route deployment steps.
+  </Card>
+  <Card
+    title="Introducing Yield Routes"
+    icon="newspaper"
+    href="https://medium.com/hyperlane/introducing-yield-routes-f7e8fd091443"
+  >
+    Post from Hyperlane Blog.
+  </Card>
+  <Card
+    title="ERC-4626 Vault Standard"
+    icon="file-lines"
+    href="https://ethereum.org/en/developers/docs/standards/tokens/erc-4626/"
+  >
+    The tokenized vault standard yield routes are built on.
+  </Card>
+</CardGroup>

--- a/docs/guides/warp-routes/evm/deploy-yield-routes.mdx
+++ b/docs/guides/warp-routes/evm/deploy-yield-routes.mdx
@@ -2,7 +2,11 @@
 title: "Deploy Yield Routes"
 ---
 
-The goal of this guide is to illustrate how you can use Hyperlane Warp Routes (HWR) to create yield-generating bridges, ensuring idle bridged assets are productive by compounding yield over time. Depending on the variant (more details below), yields are distributed to the yield route owner or users.
+The goal of this guide is to illustrate how you can use Hyperlane Warp Routes (HWR) to create yield-generating bridges, ensuring idle bridged assets are productive by compounding yield over time.
+
+<Tip>
+  For an introduction, see the [Yield Routes overview](/docs/applications/warp-routes/yield-routes).
+</Tip>
 
 <Note>
   **If you are a vault provider**, you only need to supply your ERC-4626 vault
@@ -112,11 +116,11 @@ To learn more about yield routes and the underlying standards:
     In-depth walkthrough of the underlying warp route deployment steps.
   </Card>
   <Card
-    title="Introducing Yield Routes"
-    icon="newspaper"
-    href="https://medium.com/hyperlane/introducing-yield-routes-f7e8fd091443"
+    title="Yield Routes Overview"
+    icon="book-open"
+    href="/docs/applications/warp-routes/yield-routes"
   >
-    Post from Hyperlane Blog.
+    What yield routes are, when to use them, and how they work.
   </Card>
   <Card
     title="ERC-4626 Vault Standard"

--- a/docs/guides/warp-routes/evm/deploy-yield-routes.mdx
+++ b/docs/guides/warp-routes/evm/deploy-yield-routes.mdx
@@ -4,6 +4,12 @@ title: "Deploy Yield Routes"
 
 The goal of this guide is to illustrate how you can use Hyperlane Warp Routes (HWR) to create yield-generating bridges, ensuring idle bridged assets are productive by compounding yield over time. Depending on the variant (more details below), yields are distributed to the yield route owner or users.
 
+**If you are a vault provider**, you only need to supply your ERC-4626 vault address on the origin chain. Hyperlane (or your integration partner) handles deploying and operating the route. Share this guide with the party doing the deployment and provide them with your vault address.
+
+## Vault Compatibility
+
+Your vault must implement the [ERC-4626 standard](https://ethereum.org/en/developers/docs/standards/tokens/erc-4626/) faithfully. Vaults that charge a fee on deposit/withdrawal, use a rebasing underlying asset, or override standard share math may produce incorrect exchange rates or accounting errors. If unsure, verify that `previewDeposit`, `convertToAssets`, and `convertToShares` return values consistent with the standard before integrating.
+
 ## Pre-Requisites
 
 To complete the following walkthrough, you should have the following available:
@@ -33,7 +39,7 @@ Below is the bridging flow between Ethereum and yourchain
 
 ```mermaid
 flowchart LR
-    A[Ethereum:<br>Alice] -->|Deposit USDC| B[yourchain:<br>EvmHypOwnerCollateral]
+    A[Ethereum:<br>Alice] -->|Deposit USDC| B[Ethereum:<br>EvmHypOwnerCollateral]
     B -->|USDC Deposit into Vault| C[Ethereum:<br>ERC-4626 Vault]
     C -->|Yield Generation| C
     B ==>|Bridge| E[yourchain:<br>EvmHypSynthetic]
@@ -63,8 +69,8 @@ Using the Hyperlane CLI, deploy a USDC EvmHypOwnerCollateral and EvmHypSynthetic
 #### 1. Run `hyperlane warp init` to generate a HWR config:
 
 1.  Select `yourchain` and `Ethereum` using space, and hit enter.
-2.  For Ethereum, select `collateralVault`, accept the mailbox, and enter the USDC vault address on yourchain.
-    - Alternatively, you can select `collateralVaultRebase` which is a yield route variant that distribute yields to users by increasing their holding amount.
+2.  For Ethereum, select `collateralVault`, accept the mailbox, and enter the USDC vault address on Ethereum.
+    - Alternatively, you can select `collateralVaultRebase` which is a yield route variant that distributes yields to users by increasing their holding amount.
 3.  For yourchain, select `synthetic` and accept the mailbox.
 
     - If you selected `collateralVaultRebase`, you must pair it with a `syntheticRebase`
@@ -73,7 +79,10 @@ Using the Hyperlane CLI, deploy a USDC EvmHypOwnerCollateral and EvmHypSynthetic
 
 ### Claiming Yield
 
-Depending on the yield route variant, yield can be claimed by either calling `HypERC4626OwnerCollateral.sweep()` or `HypERC4626Collateral.rebase()` on their respective contracts.
+Depending on the yield route variant:
+
+- **`collateralVault` (owner yield)**: Call `HypERC4626OwnerCollateral.sweep()` on the origin chain collateral contract. This sends all accrued yield to the contract owner address set at deployment. There is no fixed cadence — call it as often as desired.
+- **`collateralVaultRebase` (user yield)**: Call `HypERC4626Collateral.rebase(destinationDomain)` on the origin chain collateral contract. This sends an updated exchange rate to the synthetic contract on the destination chain, increasing all user balances proportionally. Again, call frequency is up to the operator.
 
 <Check>
   🎉 Congrats! You have now created a new yield route with your vault. Bridged


### PR DESCRIPTION
## Summary

- Added vault provider framing: clarifies they only need to supply their ERC-4626 vault address; Hyperlane/partner handles deployment
- Added Vault Compatibility section: flags fee-on-deposit vaults, rebasing underlyings, and non-standard share math as incompatible
- Expanded Claiming Yield section: explains who calls `sweep()`/`rebase()`, where yield lands, and that cadence is operator-controlled

## Errors Fixed

- `EvmHypOwnerCollateral` was labeled as `yourchain` in the bridge diagram — corrected to `Ethereum` (it's the origin chain collateral contract)
- Step 2 of deployment said "enter the USDC vault address on yourchain" — corrected to "on Ethereum"
- Grammar fix: "distribute yields" → "distributes yields"
- Updated `mintlify dev` → `mint dev` in README and CLAUDE.md (correct CLI command)