### PR TITLE
docs: add Rate Limit ISM and Pausable ISM configuration guides

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -155,7 +155,9 @@
                     "group": "HWR Deployment",
                     "pages": [
                       "docs/guides/production/warp-route-deployment/remove-trusted-relayer",
-                      "docs/guides/production/warp-route-deployment/transfer-warp-route-ownership"
+                      "docs/guides/production/warp-route-deployment/transfer-warp-route-ownership",
+                      "docs/guides/production/warp-route-deployment/configure-rate-limit-ism",
+                      "docs/guides/production/warp-route-deployment/configure-pausable-ism"
                     ]
                   }
                 ]

--- a/docs/guides/production/prod-overview.mdx
+++ b/docs/guides/production/prod-overview.mdx
@@ -51,5 +51,23 @@ To begin you'll need to set up and productionize the core components of your Hyp
 Transfer ownership of the HWR to the designated production owner. This step ensures that only trusted parties have control over critical HWR settings, such as ISM configurations, Validator options, and relayer settings.
 
 </Card>
+    <Card
+      title="Configure Rate Limit ISM"
+      icon="link"
+      href="./warp-route-deployment/configure-rate-limit-ism"
+    >
+      Set, update, or remove the Rate Limit ISM on your HWR. The Rate Limit ISM
+      caps the daily token volume that can be delivered to your HWR on each
+      destination chain, bounding the worst-case loss from a bridge compromise.
+    </Card>
+    <Card
+      title="Configure Pausable ISM"
+      icon="link"
+      href="./warp-route-deployment/configure-pausable-ism"
+    >
+      Pause and unpause your HWR in an incident. The Pausable ISM is an
+      emergency stop: while paused, all inbound deliveries on that destination
+      chain are rejected.
+    </Card>
 
   </Columns>

--- a/docs/guides/production/warp-route-deployment/configure-pausable-ism.mdx
+++ b/docs/guides/production/warp-route-deployment/configure-pausable-ism.mdx
@@ -1,0 +1,163 @@
+---
+title: "Configure Pausable ISM"
+description: "Learn how to pause and unpause your Hyperlane Warp Route in an incident using the Hyperlane CLI"
+---
+
+import WarpReadSymbolChainPartial from "/snippets/warp-routes/warp-read-symbol-chain.mdx";
+import WarpApplySymbolConfigDefaultPartial from "/snippets/warp-routes/warp-apply-symbol-config-default.mdx";
+
+This guide explains how the Pausable ISM works on a Hyperlane Warp Route (HWR) and how to use it in an incident. The Pausable ISM is an emergency stop: when it is paused, every inbound delivery on that destination chain is rejected, regardless of what the other security checks would have accepted.
+
+You can confirm an HWR includes a Pausable ISM by running `warp read` and looking for `type: pausableIsm` inside the aggregation's modules.
+
+<Note>
+  This page covers the operator workflow. For the contract source, see
+  [`PausableIsm.sol`](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/solidity/contracts/isms/PausableIsm.sol).
+</Note>
+
+## Overview
+
+The Pausable ISM has two states:
+
+- **Unpaused.** It accepts every inbound message. Deliveries on the destination chain proceed as normal.
+- **Paused.** It rejects every inbound message. Deliveries on the destination chain revert at the ISM step.
+
+Each HWR has its own Pausable ISM on each destination chain it routes to. Pausing it blocks deliveries into that chain, for that HWR only — the HWR's other destinations keep operating, and any other HWR is unaffected.
+
+For example, if a USDC HWR routes into Ethereum, Arbitrum, and Base, pausing the Arbitrum ISM stops only USDC deliveries into Arbitrum on this HWR. USDC deliveries into Ethereum and Base keep going, and any other HWR on Arbitrum (such as a USDT or ETH route) is also unaffected. To stop the whole route, the ISM has to be paused on each of its destinations.
+
+Pausing takes effect immediately. Once the `pause()` transaction is confirmed on-chain, deliveries on that destination stop. There is no waiting period.
+
+The Pausable ISM is one of the security checks bundled together (an aggregation), and a transfer must pass every check to be delivered. While the Pausable ISM is paused, the aggregation can never accept a message — regardless of what the other modules would have decided.
+
+## What pausing does and does not do
+
+**Pausing does:**
+
+- Cause all inbound deliveries on the paused destination chain to revert at the ISM step.
+- Take effect as soon as the `pause()` transaction is confirmed on-chain.
+
+**Pausing does not:**
+
+- Stop users from sending messages on origin chains. Dispatches still succeed; those messages just will not be delivered until the ISM is unpaused. They accumulate as pending in the meantime.
+- Refund already-dispatched messages or fees.
+- Affect any other warp route or any other ISM. The pause is scoped to the single Pausable ISM contract being called.
+- Reset the rate limit bucket, change ownership, or modify any other module in the aggregation.
+
+When the ISM is unpaused, pending messages become deliverable again and the relayer processes them normally (subject to the other modules in the aggregation — for example, the rate limit cap still applies). No action is required on the queued messages themselves.
+
+## What you control as the owner
+
+The `PausableIsm` contract is `Ownable`. The owner is the only address allowed to call `pause()` and `unpause()`. The same signing process used for other HWR admin actions applies here.
+
+## Pause the HWR
+
+<Info>
+  **Pausing and unpausing requires the owner of the `PausableIsm`** — typically
+  the same multisig that owns the HWR. If you are not the owner, you can still
+  use `warp read` to inspect the current state, but you will not be able to
+  change it.
+</Info>
+
+There are two ways to pause: a direct contract call, or via `warp apply`. The direct call is the recommended path for incidents because it has fewer moving parts and reaches finality faster.
+
+### Emergency pause (recommended)
+
+In an active incident, skip `warp apply` and call the contract directly.
+
+#### Step 1: Find the Pausable ISM address
+
+Run `warp read` and locate the `pausableIsm` entry inside the aggregation's modules. The `address` field on that entry is the contract to call.
+
+<WarpReadSymbolChainPartial />
+
+After running `warp read`, you should see a similar config under `interchainSecurityModule`. One of the modules inside the `staticAggregationIsm` will be `type: pausableIsm`:
+
+```yaml {7-10}
+yourchain:
+  ...
+  interchainSecurityModule:
+    address: "0x..."
+    type: "staticAggregationIsm"
+    modules:
+      - type: "pausableIsm"
+        address: "0x..."
+        owner: "0x..."
+        paused: false
+      - owner: "0x..."
+        address: "0x..."
+        type: "defaultFallbackRoutingIsm"
+        domains: {}
+    threshold: 2
+```
+
+#### Step 2: Send the pause transaction
+
+From the owner multisig, send a single transaction:
+
+- **to:** the Pausable ISM address
+- **data:** `pause()` (function selector `0x8456cb59`)
+- **value:** `0`
+
+#### Step 3: Verify
+
+Once the transaction is confirmed on-chain, the next inbound delivery on that chain will revert. Reading `paused()` on the contract should return `true`.
+
+Repeat on each destination chain that needs to be stopped.
+
+### Pause via warp apply
+
+For non-urgent changes — for example, planned downtime or a drill — the state can also be flipped through `warp apply`.
+
+#### Prerequisites
+
+- The warp route ID.
+  - After deployment, the warp route ID is saved to the registry at `$HOME/.hyperlane/deployments/warp_routes/<warpRouteId>`.
+  - The format is `SYMBOL/id` (e.g., `ETH/yourid`).
+  - To list existing warp route IDs: `ls $HOME/.hyperlane/deployments/warp_routes/`
+- Access to the private key that currently owns the HWR.
+
+#### Step 1: Configuration
+
+Set `paused: true` on the `pausableIsm` entry in your warp route deployment config.
+
+```diff title="warp-route-deployment.yaml"
+      - type: pausableIsm
+        address: '0x...'
+        owner: '0x...'
+-       paused: false
++       paused: true
+```
+
+#### Step 2: Apply
+
+Using the CLI, execute by providing the warp route ID:
+
+<WarpApplySymbolConfigDefaultPartial />
+
+The SDK submits a `pause()` transaction signed by the owner.
+
+#### Step 3: Confirm
+
+Re-run `warp read` and verify `paused: true` on the `pausableIsm` entry.
+
+<Note>
+  Do not rely on this path in an emergency. It adds CLI invocation, transaction
+  building, and YAML editing on top of the multisig signing process. The direct
+  contract call is faster and has fewer moving parts.
+</Note>
+
+## Unpause the HWR
+
+Unpause mirrors the pause flow.
+
+- **Emergency path:** Send a transaction from the owner multisig to the Pausable ISM address calling `unpause()` (function selector `0x3f4ba83a`). Pending messages will start delivering as the relayer processes them.
+- **Via `warp apply`:** Set `paused: false` in the config and run `warp apply`.
+
+Verify with `paused()` on the contract or re-run `warp read` — the value should now be `false`.
+
+## Recommendations
+
+- **Practice on a testnet route before you need it.** A short drill — find the address, build the `pause()` transaction, collect signatures, broadcast — surfaces issues with the signing process while the stakes are low.
+- **Document signer availability out of band.** The Pausable ISM is only as responsive as the signers behind the owner multisig.
+- **Pause is containment, not resolution.** Pausing stops new deliveries but does not fix the underlying issue. Unpausing requires confidence that the incident has been resolved or mitigated.

--- a/docs/guides/production/warp-route-deployment/configure-pausable-ism.mdx
+++ b/docs/guides/production/warp-route-deployment/configure-pausable-ism.mdx
@@ -4,7 +4,6 @@ description: "Learn how to pause and unpause your Hyperlane Warp Route in an inc
 ---
 
 import WarpReadSymbolChainPartial from "/snippets/warp-routes/warp-read-symbol-chain.mdx";
-import WarpApplySymbolConfigDefaultPartial from "/snippets/warp-routes/warp-apply-symbol-config-default.mdx";
 
 This guide explains how the Pausable ISM works on a Hyperlane Warp Route (HWR) and how to use it in an incident. The Pausable ISM is an emergency stop: when it is paused, every inbound delivery on that destination chain is rejected, regardless of what the other security checks would have accepted.
 
@@ -59,13 +58,9 @@ The `PausableIsm` contract is `Ownable`. The owner is the only address allowed t
   change it.
 </Info>
 
-There are two ways to pause: a direct contract call, or via `warp apply`. The direct call is the recommended path for incidents because it has fewer moving parts and reaches finality faster.
+The owner sends a `pause()` transaction directly to the Pausable ISM contract. The pause takes effect as soon as the transaction is confirmed on-chain.
 
-### Emergency pause (recommended)
-
-In an active incident, skip `warp apply` and call the contract directly.
-
-#### Step 1: Find the Pausable ISM address
+### Step 1: Find the Pausable ISM address
 
 Run `warp read` and locate the `pausableIsm` entry inside the aggregation's modules. The `address` field on that entry is the contract to call.
 
@@ -91,7 +86,7 @@ yourchain:
     threshold: 2
 ```
 
-#### Step 2: Send the pause transaction
+### Step 2: Send the pause transaction
 
 From the owner multisig, send a single transaction:
 
@@ -99,60 +94,15 @@ From the owner multisig, send a single transaction:
 - **data:** `pause()` (function selector `0x8456cb59`)
 - **value:** `0`
 
-#### Step 3: Verify
+### Step 3: Verify
 
 Once the transaction is confirmed on-chain, the next inbound delivery on that chain will revert. Reading `paused()` on the contract should return `true`.
 
 Repeat on each destination chain that needs to be stopped.
 
-### Pause via warp apply
-
-For non-urgent changes — for example, planned downtime or a drill — the state can also be flipped through `warp apply`.
-
-#### Prerequisites
-
-- The warp route ID.
-  - After deployment, the warp route ID is saved to the registry at `$HOME/.hyperlane/deployments/warp_routes/<warpRouteId>`.
-  - The format is `SYMBOL/id` (e.g., `ETH/yourid`).
-  - To list existing warp route IDs: `ls $HOME/.hyperlane/deployments/warp_routes/`
-- Access to the private key that currently owns the HWR.
-
-#### Step 1: Configuration
-
-Set `paused: true` on the `pausableIsm` entry in your warp route deployment config.
-
-```diff title="warp-route-deployment.yaml"
-      - type: pausableIsm
-        address: '0x...'
-        owner: '0x...'
--       paused: false
-+       paused: true
-```
-
-#### Step 2: Apply
-
-Using the CLI, execute by providing the warp route ID:
-
-<WarpApplySymbolConfigDefaultPartial />
-
-The SDK submits a `pause()` transaction signed by the owner.
-
-#### Step 3: Confirm
-
-Re-run `warp read` and verify `paused: true` on the `pausableIsm` entry.
-
-<Note>
-  Do not rely on this path in an emergency. It adds CLI invocation, transaction
-  building, and YAML editing on top of the multisig signing process. The direct
-  contract call is faster and has fewer moving parts.
-</Note>
-
 ## Unpause the HWR
 
-Unpause mirrors the pause flow.
-
-- **Emergency path:** Send a transaction from the owner multisig to the Pausable ISM address calling `unpause()` (function selector `0x3f4ba83a`). Pending messages will start delivering as the relayer processes them.
-- **Via `warp apply`:** Set `paused: false` in the config and run `warp apply`.
+To unpause, the owner sends an `unpause()` transaction (function selector `0x3f4ba83a`) from the owner multisig to the Pausable ISM address. Pending messages will start delivering as the relayer processes them.
 
 Verify with `paused()` on the contract or re-run `warp read` — the value should now be `false`.
 

--- a/docs/guides/production/warp-route-deployment/configure-pausable-ism.mdx
+++ b/docs/guides/production/warp-route-deployment/configure-pausable-ism.mdx
@@ -8,7 +8,7 @@ import WarpApplySymbolConfigDefaultPartial from "/snippets/warp-routes/warp-appl
 
 This guide explains how the Pausable ISM works on a Hyperlane Warp Route (HWR) and how to use it in an incident. The Pausable ISM is an emergency stop: when it is paused, every inbound delivery on that destination chain is rejected, regardless of what the other security checks would have accepted.
 
-You can confirm an HWR includes a Pausable ISM by running `warp read` and looking for `type: pausableIsm` inside the aggregation's modules.
+You can confirm an HWR includes a Pausable ISM by running `warp read` and looking for `type: pausableIsm` inside the aggregation's modules. You can also check the [Hyperlane explorer](https://explorer.hyperlane.xyz/) under the **Warp Route Security** section for your route.
 
 <Note>
   This page covers the operator workflow. For the contract source, see
@@ -28,7 +28,7 @@ For example, if a USDC HWR routes into Ethereum, Arbitrum, and Base, pausing the
 
 Pausing takes effect immediately. Once the `pause()` transaction is confirmed on-chain, deliveries on that destination stop. There is no waiting period.
 
-The Pausable ISM is one of the security checks bundled together (an aggregation), and a transfer must pass every check to be delivered. While the Pausable ISM is paused, the aggregation can never accept a message — regardless of what the other modules would have decided.
+A typical aggregation contains Pausable + Rate Limit + Default Fallback in a 3/3 setup — all three modules must accept a message for it to be delivered. While the Pausable ISM is paused, the aggregation can never accept a message: the paused module rejects everything, and the aggregation requires every module to accept.
 
 ## What pausing does and does not do
 

--- a/docs/guides/production/warp-route-deployment/configure-pausable-ism.mdx
+++ b/docs/guides/production/warp-route-deployment/configure-pausable-ism.mdx
@@ -22,7 +22,7 @@ The Pausable ISM has two states:
 - **Unpaused.** It accepts every inbound message. Deliveries on the destination chain proceed as normal.
 - **Paused.** It rejects every inbound message. Deliveries on the destination chain revert at the ISM step.
 
-Each HWR has its own Pausable ISM on each destination chain it routes to. Pausing it blocks deliveries into that chain, for that HWR only — the HWR's other destinations keep operating, and any other HWR is unaffected.
+An HWR that includes a Pausable ISM has one instance per destination chain it routes to. Pausing it blocks deliveries into that chain, for that HWR only — the HWR's other destinations keep operating, and any other HWR is unaffected.
 
 For example, if a USDC HWR routes into Ethereum, Arbitrum, and Base, pausing the Arbitrum ISM stops only USDC deliveries into Arbitrum on this HWR. USDC deliveries into Ethereum and Base keep going, and any other HWR on Arbitrum (such as a USDT or ETH route) is also unaffected. To stop the whole route, the ISM has to be paused on each of its destinations.
 
@@ -44,7 +44,7 @@ The Pausable ISM is one of the security checks bundled together (an aggregation)
 - Affect any other warp route or any other ISM. The pause is scoped to the single Pausable ISM contract being called.
 - Reset the rate limit bucket, change ownership, or modify any other module in the aggregation.
 
-When the ISM is unpaused, pending messages become deliverable again and the relayer processes them normally (subject to the other modules in the aggregation — for example, the rate limit cap still applies). No action is required on the queued messages themselves.
+When the ISM is unpaused, pending messages become deliverable again and the relayer resumes processing them (subject to its retry window and the other modules in the aggregation — for example, the rate limit cap still applies). Messages that aged out of the relayer's retry window during the pause may require manual re-relay.
 
 ## What you control as the owner
 

--- a/docs/guides/production/warp-route-deployment/configure-rate-limit-ism.mdx
+++ b/docs/guides/production/warp-route-deployment/configure-rate-limit-ism.mdx
@@ -8,7 +8,7 @@ import WarpApplySymbolConfigDefaultPartial from "/snippets/warp-routes/warp-appl
 
 This guide explains how to configure the Rate Limit ISM on your Hyperlane Warp Route (HWR) using the Hyperlane CLI. The Rate Limit ISM caps the total token volume that can be delivered to your HWR on each destination chain within a rolling 24-hour window.
 
-The cap is set by the HWR owner and bounds the worst-case loss from a single incident. If a token contract is exploited, a validator key is leaked, or a relayer is compromised, an attacker can drain at most `maxCapacity` per day before further deliveries are blocked. This gives the owner time to detect the incident and [pause the route](/docs/guides/production/warp-route-deployment/configure-pausable-ism).
+The cap is set by the HWR owner and bounds the worst-case loss from a single incident. If a token contract is exploited, a validator key is leaked, or a relayer is compromised, an attacker can drain at most `maxCapacity` per day before further deliveries are blocked.
 
 <Note>
   This page covers the operator workflow. For protocol-level detail and contract

--- a/docs/guides/production/warp-route-deployment/configure-rate-limit-ism.mdx
+++ b/docs/guides/production/warp-route-deployment/configure-rate-limit-ism.mdx
@@ -1,0 +1,169 @@
+---
+title: "Configure Rate Limit ISM"
+description: "Learn how to set, update, or remove the Rate Limit ISM on your Hyperlane Warp Route using the Hyperlane CLI"
+---
+
+import WarpReadSymbolChainPartial from "/snippets/warp-routes/warp-read-symbol-chain.mdx";
+import WarpApplySymbolConfigDefaultPartial from "/snippets/warp-routes/warp-apply-symbol-config-default.mdx";
+
+This guide explains how to configure the Rate Limit ISM on your Hyperlane Warp Route (HWR) using the Hyperlane CLI. The Rate Limit ISM caps the total token volume that can be delivered to your HWR on each destination chain within a rolling 24-hour window.
+
+The cap is set by the HWR owner and bounds the worst-case loss from a single incident. If a token contract is exploited, a validator key is leaked, or a relayer is compromised, an attacker can drain at most `maxCapacity` per day before further deliveries are blocked. This gives the owner time to detect the incident and [pause the route](/docs/guides/production/warp-route-deployment/configure-pausable-ism).
+
+<Note>
+  This page covers the operator workflow. For protocol-level detail and contract
+  reference, see [Rate Limited
+  ISM](/docs/protocol/ISM/standard-ISMs/rate-limited-ISM).
+</Note>
+
+## Overview
+
+The Rate Limit ISM puts a daily ceiling on how much volume can move through your HWR into a given destination chain. It uses a token bucket that refills continuously throughout the day:
+
+- The bucket starts full at `maxCapacity`.
+- It refills at a steady rate — `maxCapacity / 86400` per second — so one full bucket every 24 hours.
+- Each incoming transfer uses up part of the bucket, equal to the amount being transferred.
+- If a transfer would exceed the available bucket capacity, it does not go through right away. The message stays pending and becomes deliverable again as the bucket refills.
+
+The Rate Limit ISM does not work in isolation. It is one of the security checks bundled together (an aggregation), and a transfer must pass every check in the bundle to be delivered. The rate limit adds a volume ceiling on top of your existing security.
+
+<Note>
+  `maxCapacity` is denominated in the token's smallest base unit. For a 6-decimal token like USDC, `1000000000000` means 1,000,000 USDC per day. For an 18-decimal token, `5000000000000000000000000` means 5,000,000 tokens per day.
+
+The SDK requires `maxCapacity` to be at least `86400` and rounds it down to the nearest multiple of `86400` so the per-second refill rate is a whole number. For example, `5000000000000000000000000` rounds down to `4999999999999999999968000`.
+
+</Note>
+
+## What you control as the owner
+
+The `RateLimitedIsm` contract is `Ownable`. The owner — typically the same multisig that owns the HWR — is the only address allowed to update the cap (via `setRefillRate`).
+
+As the owner, you are responsible for:
+
+- **Sizing the cap.** Leave enough headroom for normal use while keeping the cap low enough that a compromise has a meaningful limit.
+- **Monitoring saturation.** Sustained use near the cap is a signal to raise the limit. Large unexplained spikes are a signal to investigate before raising it.
+- **Adjusting over time.** Caps should be revisited as volume grows.
+
+<Note>
+  `setRefillRate` updates the refill rate going forward. It does not reset the
+  current bucket level. If the bucket is half-empty when you raise the cap, it
+  stays half-empty in absolute terms and refills toward the new ceiling at the
+  new rate. The same applies when you lower the cap.
+</Note>
+
+## Update the cap
+
+<Info>
+  **This section is for HWR owners.** Only the address that owns the
+  `RateLimitedIsm` can update the cap. If you are not the owner, you can still
+  use `warp read` to inspect the current cap, but you will not be able to apply
+  changes.
+</Info>
+
+The Rate Limit ISM is updated the same way as any other HWR configuration: edit the YAML in your local registry, then run `warp apply`. The SDK detects the change and submits a `setRefillRate` transaction signed by the ISM owner.
+
+### Prerequisites
+
+- The warp route ID.
+  - After deployment, the warp route ID is saved to the registry at `$HOME/.hyperlane/deployments/warp_routes/<warpRouteId>`.
+  - The format is `SYMBOL/id` (e.g., `ETH/yourid`).
+  - To list existing warp route IDs: `ls $HOME/.hyperlane/deployments/warp_routes/`
+- Access to the private key that currently owns the HWR.
+
+To fetch the current on-chain config, run the following:
+
+<WarpReadSymbolChainPartial />
+
+After running `warp read`, you should see a similar config under `interchainSecurityModule`. One of the modules inside the `staticAggregationIsm` will be `type: rateLimitedIsm` with the current `maxCapacity`:
+
+```yaml {7-10}
+yourchain:
+  ...
+  interchainSecurityModule:
+    address: "0x..."
+    type: "staticAggregationIsm"
+    modules:
+      - type: "rateLimitedIsm"
+        address: "0x..."
+        owner: "0x..."
+        maxCapacity: "1000000000000"
+      - owner: "0x..."
+        address: "0x..."
+        type: "defaultFallbackRoutingIsm"
+        domains: {}
+    threshold: 2
+```
+
+<Info>
+Warp route configs are stored in your local registry at `$HOME/.hyperlane/deployments/warp_routes/<warpRouteId>/`. The `warp read` command outputs the current on-chain config for reference.
+</Info>
+
+Follow these steps using the CLI to update the cap.
+
+### Step 1: Configuration
+
+Update `maxCapacity` on the `rateLimitedIsm` module in your warp route deployment config. For example, to raise the cap from 1M to 5M USDC per day:
+
+```diff title="warp-route-deployment.yaml"
+yourchain:
+  mailbox: '0x...'
+  owner: '0x...'
+  interchainSecurityModule:
+    address: '0x...'
+    type: 'staticAggregationIsm'
+    modules:
+      - type: rateLimitedIsm
+        address: '0x...'
+        owner: '0x...'
+-       maxCapacity: '1000000000000'
++       maxCapacity: '5000000000000'
+      - owner: '0x...'
+        address: '0x...'
+        type: 'defaultFallbackRoutingIsm'
+        domains: {}
+    threshold: 2
+```
+
+<Note>
+  The SDK fills in operational fields (such as the bound recipient address)
+  automatically when it deploys the ISM. You only need to edit `maxCapacity` and
+  `owner`.
+</Note>
+
+### Step 2: Apply
+
+Using the CLI, execute by providing the warp route ID:
+
+<WarpApplySymbolConfigDefaultPartial />
+
+You should see a single transaction calling `setRefillRate` on the ISM contract, signed by the owner.
+
+### Step 3: Confirm
+
+To confirm the new cap is on-chain, re-run the read command:
+
+<WarpReadSymbolChainPartial />
+
+After running `warp read`, you should see the updated `maxCapacity` (rounded down to the nearest multiple of `86400` if needed):
+
+```yaml {4}
+- type: "rateLimitedIsm"
+  address: "0x..."
+  owner: "0x..."
+  maxCapacity: "4999999968000"
+```
+
+## Removing the Rate Limit ISM
+
+The Rate Limit ISM is an effective defense against a bridge compromise and has no effect on traffic below the cap.
+
+If you have a specific reason to remove it — for example, you are layering an alternative volume-control mechanism upstream — you can do so by removing the `rateLimitedIsm` entry from the aggregation:
+
+1. Run `warp read` to fetch the current config.
+2. In your local deployment config, delete the entire `rateLimitedIsm` entry from the aggregation's `modules` list. Keep the other modules in place.
+3. Run `warp apply`. The SDK deploys a new aggregation ISM without the rate limit module and points the warp route at it. The old `RateLimitedIsm` contract remains on chain but is no longer referenced.
+4. Re-run `warp read` to confirm the `rateLimitedIsm` is no longer in the module list.
+
+You can re-add it later by adding the module back to the config and running `warp apply` again. This deploys a fresh `RateLimitedIsm` with the cap you specify.
+
+By completing these steps, you have configured the Rate Limit ISM on your HWR.

--- a/docs/guides/production/warp-route-deployment/configure-rate-limit-ism.mdx
+++ b/docs/guides/production/warp-route-deployment/configure-rate-limit-ism.mdx
@@ -21,11 +21,11 @@ The cap is set by the HWR owner and bounds the worst-case loss from a single inc
 The Rate Limit ISM puts a daily ceiling on how much volume can move through your HWR into a given destination chain. It uses a token bucket that refills continuously throughout the day:
 
 - The bucket starts full at `maxCapacity`.
-- It refills at a steady rate — `maxCapacity / 86400` per second — so one full bucket every 24 hours.
+- It refills continuously at `maxCapacity / 86400` per second, every second. This is a **rolling window**, not a daily quota that resets at midnight or any other fixed time. If the bucket is drained at any moment, capacity starts returning the very next second; after 24 hours with no transfers, the bucket is fully topped up again.
 - Each incoming transfer uses up part of the bucket, equal to the amount being transferred.
 - If a transfer would exceed the available bucket capacity, it does not go through right away. The message stays pending and becomes deliverable again as the bucket refills, subject to the relayer's retry behavior.
 
-The Rate Limit ISM does not work in isolation. It is one of the security checks bundled together (an aggregation), and a transfer must pass every check in the bundle to be delivered. The rate limit adds a volume ceiling on top of your existing security.
+The Rate Limit ISM can be deployed alone, but a typical aggregation contains Pausable + Rate Limit + Default Fallback in a 3/3 setup — all three modules must accept a message for it to be delivered. The rate limit adds a volume ceiling on top of the other security checks.
 
 <Note>
   `maxCapacity` is denominated in the token's smallest base unit. For a 6-decimal token like USDC, `1000000000000` means 1,000,000 USDC per day. For an 18-decimal token, `5000000000000000000000000` means 5,000,000 tokens per day.

--- a/docs/guides/production/warp-route-deployment/configure-rate-limit-ism.mdx
+++ b/docs/guides/production/warp-route-deployment/configure-rate-limit-ism.mdx
@@ -23,20 +23,19 @@ The Rate Limit ISM puts a daily ceiling on how much volume can move through your
 - The bucket starts full at `maxCapacity`.
 - It refills at a steady rate — `maxCapacity / 86400` per second — so one full bucket every 24 hours.
 - Each incoming transfer uses up part of the bucket, equal to the amount being transferred.
-- If a transfer would exceed the available bucket capacity, it does not go through right away. The message stays pending and becomes deliverable again as the bucket refills.
+- If a transfer would exceed the available bucket capacity, it does not go through right away. The message stays pending and becomes deliverable again as the bucket refills, subject to the relayer's retry behavior.
 
 The Rate Limit ISM does not work in isolation. It is one of the security checks bundled together (an aggregation), and a transfer must pass every check in the bundle to be delivered. The rate limit adds a volume ceiling on top of your existing security.
 
 <Note>
   `maxCapacity` is denominated in the token's smallest base unit. For a 6-decimal token like USDC, `1000000000000` means 1,000,000 USDC per day. For an 18-decimal token, `5000000000000000000000000` means 5,000,000 tokens per day.
 
-The SDK requires `maxCapacity` to be at least `86400` and rounds it down to the nearest multiple of `86400` so the per-second refill rate is a whole number. For example, `5000000000000000000000000` rounds down to `4999999999999999999968000`.
-
+  The SDK requires `maxCapacity` to be at least `86400` and rounds it down to the nearest multiple of `86400` so the per-second refill rate is a whole number. For example, `5000000000000000000000000` rounds down to `4999999999999999999968000`.
 </Note>
 
 ## What you control as the owner
 
-The `RateLimitedIsm` contract is `Ownable`. The owner — typically the same multisig that owns the HWR — is the only address allowed to update the cap (via `setRefillRate`).
+The `RateLimitedIsm` contract is `Ownable`. The owner — typically the same multisig that owns the HWR — is the only address allowed to update the cap. You change it by editing `maxCapacity` in your warp route config; the SDK applies the change by calling `setRefillRate` on the ISM.
 
 As the owner, you are responsible for:
 
@@ -86,7 +85,7 @@ yourchain:
       - type: "rateLimitedIsm"
         address: "0x..."
         owner: "0x..."
-        maxCapacity: "1000000000000"
+        maxCapacity: "999999993600"
       - owner: "0x..."
         address: "0x..."
         type: "defaultFallbackRoutingIsm"
@@ -115,7 +114,7 @@ yourchain:
       - type: rateLimitedIsm
         address: '0x...'
         owner: '0x...'
--       maxCapacity: '1000000000000'
+-       maxCapacity: '999999993600'
 +       maxCapacity: '5000000000000'
       - owner: '0x...'
         address: '0x...'

--- a/docs/guides/production/warp-route-deployment/configure-rate-limit-ism.mdx
+++ b/docs/guides/production/warp-route-deployment/configure-rate-limit-ism.mdx
@@ -8,7 +8,7 @@ import WarpApplySymbolConfigDefaultPartial from "/snippets/warp-routes/warp-appl
 
 This guide explains how to configure the Rate Limit ISM on your Hyperlane Warp Route (HWR) using the Hyperlane CLI. The Rate Limit ISM caps the total token volume that can be delivered to your HWR on each destination chain within a rolling 24-hour window.
 
-The cap is set by the HWR owner and bounds the worst-case loss from a single incident. If a token contract is exploited, a validator key is leaked, or a relayer is compromised, an attacker can drain at most `maxCapacity` per day before further deliveries are blocked.
+The cap is set by the HWR owner and bounds the worst-case loss from a single incident. If a token contract is exploited or a validator key is leaked, an attacker can drain at most `maxCapacity` per day before further deliveries are blocked.
 
 <Note>
   This page covers the operator workflow. For protocol-level detail and contract
@@ -25,7 +25,7 @@ The Rate Limit ISM puts a daily ceiling on how much volume can move through your
 - Each incoming transfer uses up part of the bucket, equal to the amount being transferred.
 - If a transfer would exceed the available bucket capacity, it does not go through right away. The message stays pending and becomes deliverable again as the bucket refills, subject to the relayer's retry behavior.
 
-The Rate Limit ISM can be deployed alone, but a typical aggregation contains Pausable + Rate Limit + Default Fallback in a 3/3 setup — all three modules must accept a message for it to be delivered. The rate limit adds a volume ceiling on top of the other security checks.
+The Rate Limit ISM does not verify messages on its own; it only enforces a volume cap. It is always deployed inside an aggregation alongside an ISM that does the actual verification. A typical aggregation contains Pausable + Rate Limit + Default Fallback in a 3/3 setup — all three modules must accept a message for it to be delivered. The rate limit adds a volume ceiling on top of the other security checks.
 
 <Note>
   `maxCapacity` is denominated in the token's smallest base unit. For a 6-decimal token like USDC, `1000000000000` means 1,000,000 USDC per day. For an 18-decimal token, `5000000000000000000000000` means 5,000,000 tokens per day.


### PR DESCRIPTION
## Summary

Adds two new operator guides under **Go to Production / HWR Deployment** so customers can self-serve when adjusting these HWR security modules:

- **Configure Rate Limit ISM** — daily volume cap bounding worst-case loss from a bridge compromise. Covers inspecting, updating, and removing the cap.
- **Configure Pausable ISM** — emergency stop that rejects all inbound deliveries on a destination when paused. Walks through both the direct contract call (recommended for incidents) and the `warp apply` path.

Both pages lead with role-neutral conceptual sections so non-owners landing on the page still understand what the ISM does, with owner-only callouts on the action sections.

Nav entries added to `docs.json` and Cards added to `prod-overview.mdx`.

## Test plan

- [ ] `mint dev` — verify both pages render and right-hand TOC nests correctly under `## Update the cap` (rate-limit) and `## Pause the HWR` (pausable)
- [ ] `mint broken-links` — verify internal links resolve (rate-limit → `/docs/protocol/ISM/standard-ISMs/rate-limited-ISM` and the new pausable page; pausable → `PausableIsm.sol` on GitHub)
- [ ] **Eng review for technical accuracy:**
  - Function selectors `0x8456cb59` (`pause()`) and `0x3f4ba83a` (`unpause()`)
  - `setRefillRate` does not reset the current bucket level
  - Rounding math: 5M USDC (`5000000000000`) rounds down to `4999999968000`
  - `staticAggregationIsm` accept-all-modules semantics (used to justify the claim that pausing one module blocks the whole aggregation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)