### PR TITLE
chore: update Claude review workflow to Opus 4.8

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,7 +9,7 @@ on:
     types: [created]
 
 env:
-  CLAUDE_OPUS_MODEL: claude-opus-4-7
+  CLAUDE_OPUS_MODEL: claude-opus-4-8
   CLAUDE_SONNET_MODEL: claude-sonnet-4-6
 
 concurrency:


### PR DESCRIPTION
Updates `CLAUDE_OPUS_MODEL` in the Claude docs review workflow from `claude-opus-4-7` to `claude-opus-4-8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)