### PR TITLE
docs: add hosted mainnet and testnet relay API endpoints

### DIFF
--- a/docs/operate/relayer/api.mdx
+++ b/docs/operate/relayer/api.mdx
@@ -47,9 +47,14 @@ Most endpoints do not require authentication for read operations. Write operatio
 
 ## Base URL
 
-The default base URL for local development is:
+Hyperlane hosts public relay API endpoints:
+
+| Network | URL |
+|---------|-----|
+| Mainnet | `https://relay-api.hyperlane.xyz/relay` |
+| Testnet | `https://testnet-relay-api.hyperlane.xyz/relay` |
+
+For self-hosted relayers, the default base URL for local development is:
 ```
 http://localhost:9090
 ```
-
-Update this to match your relayer's actual endpoint when deployed.

--- a/docs/operate/relayer/api/relay/post-relay.mdx
+++ b/docs/operate/relayer/api/relay/post-relay.mdx
@@ -38,9 +38,17 @@ Non-eligible messages (e.g. non-CCTP V2) are silently skipped. The response only
   </Expandable>
 </Expandable>
 
+<Note>
+Hyperlane hosts public relay API endpoints:
+- **Mainnet**: `https://relay-api.hyperlane.xyz/relay`
+- **Testnet**: `https://testnet-relay-api.hyperlane.xyz/relay`
+
+For self-hosted relayers, replace the URL with your relayer's address (default: `http://localhost:9090/relay`).
+</Note>
+
 <RequestExample>
-```bash curl
-curl -X POST http://localhost:9090/relay \
+```bash Mainnet
+curl -X POST https://relay-api.hyperlane.xyz/relay \
   -H "Content-Type: application/json" \
   -d '{
     "origin_chain": "base",
@@ -48,8 +56,17 @@ curl -X POST http://localhost:9090/relay \
   }'
 ```
 
+```bash Testnet
+curl -X POST https://testnet-relay-api.hyperlane.xyz/relay \
+  -H "Content-Type: application/json" \
+  -d '{
+    "origin_chain": "basesepolia",
+    "tx_hash": "0xabc123..."
+  }'
+```
+
 ```javascript JavaScript
-const response = await fetch('http://localhost:9090/relay', {
+const response = await fetch('https://relay-api.hyperlane.xyz/relay', {
   method: 'POST',
   headers: { 'Content-Type': 'application/json' },
   body: JSON.stringify({
@@ -63,7 +80,7 @@ const { messages } = await response.json();
 ```python Python
 import requests
 
-response = requests.post('http://localhost:9090/relay', json={
+response = requests.post('https://relay-api.hyperlane.xyz/relay', json={
     'origin_chain': 'base',
     'tx_hash': '0xabc123...',
 })


### PR DESCRIPTION
## Summary

- Adds a table to the Relayer HTTP API overview listing the public Hyperlane-hosted mainnet (`https://relay-api.hyperlane.xyz/relay`) and testnet (`https://testnet-relay-api.hyperlane.xyz/relay`) endpoints
- Adds a `<Note>` to the Submit Transaction for Relay page calling out both hosted URLs
- Splits the curl request example into separate Mainnet and Testnet tabs; updates JS and Python examples to use the mainnet URL

## Test plan

- [x] Verify both endpoint URLs render correctly in the docs
- [x] Confirm Mainnet/Testnet curl tabs display properly in Mintlify

🤖 Generated with [Claude Code](https://claude.com/claude-code)