### PR TITLE
docs: update deprecated chains (July 10 batch)

### DIFF
--- a/docs/reference/deprecated-chains.mdx
+++ b/docs/reference/deprecated-chains.mdx
@@ -16,10 +16,10 @@ Abacus Works is winding down its [Relayer](/docs/protocol/agents/relayer) and [V
 | Chain         | Domain ID  | Chain ID   | Last Supported Date |
 |---------------|------------|------------|---------------------|
 | Arbitrum Nova | 42170      | 42170      | May 10, 2026        |
-| Artela        | 11820      | 11820      | June 1, 2026        |
+| Artela        | 11820      | 11820      | May 10, 2026        |
 | Astar         | 592        | 592        | July 10, 2026       |
 | Aurora        | 1313161554 | 1313161554 | May 10, 2026        |
-| B² Network    | 223        | 223        | June 1, 2026        |
+| B² Network    | 223        | 223        | May 10, 2026        |
 | B3            | 8333       | 8333       | May 10, 2026        |
 | Chiliz        | 1000088888 | 88888      | July 10, 2026       |
 | Degen         | 666666666  | 666666666  | May 10, 2026        |

--- a/docs/reference/deprecated-chains.mdx
+++ b/docs/reference/deprecated-chains.mdx
@@ -52,7 +52,7 @@ Abacus Works is winding down its [Relayer](/docs/protocol/agents/relayer) and [V
 | Torus         | 21000      | 21000      | July 10, 2026       |
 | XRPL EVM      | 1440000    | 1440000    | July 10, 2026       |
 | Zero Network  | 543210     | 543210     | June 1, 2026        |
-| Zora          | 7777777    | 7777777    | May 10, 2026        |
 | Zircuit       | 48900      | 48900      | July 10, 2026       |
+| Zora          | 7777777    | 7777777    | May 10, 2026        |
 
 *Chain and domain IDs sourced from the [Hyperlane Registry](https://github.com/hyperlane-xyz/hyperlane-registry).*

--- a/docs/reference/deprecated-chains.mdx
+++ b/docs/reference/deprecated-chains.mdx
@@ -16,33 +16,43 @@ Abacus Works is winding down its [Relayer](/docs/protocol/agents/relayer) and [V
 | Chain         | Domain ID  | Chain ID   | Last Supported Date |
 |---------------|------------|------------|---------------------|
 | Arbitrum Nova | 42170      | 42170      | May 10, 2026        |
-| Artela        | 11820      | 11820      | May 10, 2026        |
+| Artela        | 11820      | 11820      | June 1, 2026        |
+| Astar         | 592        | 592        | July 10, 2026       |
 | Aurora        | 1313161554 | 1313161554 | May 10, 2026        |
-| B² Network    | 223        | 223        | May 10, 2026        |
+| B² Network    | 223        | 223        | June 1, 2026        |
 | B3            | 8333       | 8333       | May 10, 2026        |
+| Chiliz        | 1000088888 | 88888      | July 10, 2026       |
 | Degen         | 666666666  | 666666666  | May 10, 2026        |
 | Dogechain     | 2000       | 2000       | May 10, 2026        |
+| Endurance     | 648        | 648        | June 7, 2026        |
 | Everclear     | 25327      | 25327      | May 10, 2026        |
 | Fantom Opera  | 250        | 250        | May 10, 2026        |
 | Fluence       | 9999999    | 9999999    | May 10, 2026        |
 | Harmony One   | 1666600000 | 1666600000 | May 10, 2026        |
-| Manta Pacific | 169        | 169        | June 30, 2026       |
+| Incentiv      | 24101      | 24101      | July 10, 2026       |
+| Lit Chain     | 175200     | 175200     | June 16, 2026       |
+| Manta Pacific | 169        | 169        | July 10, 2026       |
 | Merlin        | 4200       | 4200       | May 10, 2026        |
 | MilkyWay      | 1835625579 | milkyway   | May 10, 2026        |
-| Molten        | 360        | 360        | May 10, 2026        |
+| Miraclechain  | 92278      | 92278      | June 29, 2026       |
+| Molten        | 360        | 360        | June 1, 2026        |
 | Moonbeam      | 1284       | 1284       | May 10, 2026        |
-| Neutron       | 1853125230 | neutron-1  | May 10, 2026        |
+| Neutron       | 1853125230 | neutron-1  | March 14, 2026      |
+| Ontology      | 58         | 58         | July 10, 2026       |
 | Polygon zkEVM | 1101       | 1101       | May 10, 2026        |
 | Polynomial    | 1000008008 | 8008       | May 10, 2026        |
 | Redstone      | 690        | 690        | May 25, 2026        |
 | Scroll        | 534352     | 534352     | May 10, 2026        |
+| Sophon        | 50104      | 50104      | May 20, 2026        |
 | Story Mainnet | 1514       | 1514       | May 10, 2026        |
+| Stride        | 745        | stride-1   | July 10, 2026       |
 | Superposition | 1000055244 | 55244      | May 10, 2026        |
-| Swellchain    | 1923       | 1923       | June 30, 2026       |
+| Swellchain    | 1923       | 1923       | June 28, 2026       |
 | Tangle        | 5845       | 5845       | May 10, 2026        |
-| Torus         | 21000      | 21000      | June 9, 2026        |
-| Zero Network  | 543210     | 543210     | May 10, 2026        |
+| Torus         | 21000      | 21000      | July 10, 2026       |
+| XRPL EVM      | 1440000    | 1440000    | July 10, 2026       |
+| Zero Network  | 543210     | 543210     | June 1, 2026        |
 | Zora          | 7777777    | 7777777    | May 10, 2026        |
-| Zircuit       | 48900      | 48900      | August 20, 2026     |
+| Zircuit       | 48900      | 48900      | July 10, 2026       |
 
 *Chain and domain IDs sourced from the [Hyperlane Registry](https://github.com/hyperlane-xyz/hyperlane-registry).*


### PR DESCRIPTION
Updates the [Deprecated Chains](/docs/reference/deprecated-chains) page.

## New chains added (July 10, 2026)
Astar, Chiliz, Endurance, Incentiv, Lit Chain, Miraclechain, Ontology, Sophon, Stride, XRPL EVM. IDs sourced from the Hyperlane Registry.

## Dates updated on existing chains

**Infra removal already done → June 1, 2026:**
- Molten — June 1
- Zero Network — June 1

**Last active date used:**
- Neutron — March 14
- Sophon — May 20
- Lit Chain — June 16
- Miraclechain — June 29
- Swellchain — June 28
- Endurance — June 7

**July 10, 2026 batch:** Manta Pacific, Torus, Zircuit, plus new chains above.

**Unchanged:** Artela and B² Network stay at May 10, 2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)