### PR TITLE
ci: fix pnpm 11 install failure blocking weekly dependency updates

### DIFF
--- a/scripts/pnpm-workspace.yaml
+++ b/scripts/pnpm-workspace.yaml
@@ -1,0 +1,10 @@
+# pnpm 11 fails installs until dependency build scripts are explicitly
+# allowed or denied. None of these native builds are needed to run the
+# docs generation scripts, so deny them all.
+allowBuilds:
+  bigint-buffer: false
+  bufferutil: false
+  core-js: false
+  protobufjs: false
+  secp256k1: false
+  utf-8-validate: false


### PR DESCRIPTION
## Problem

The scheduled `update-hyperlane-deps` workflow has **failed every Monday since May 25, 2026**, so no automated SDK/Registry update PRs have been opened since #93 (April 27). Docs are pinned to SDK `34.0.0` / Registry `25.1.0` while the latest are `35.2.0` / `25.3.0`.

Every run dies at the `pnpm install` step:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: bigint-buffer@1.1.5, bufferutil@4.0.9,
core-js@3.48.0, protobufjs@6.11.4, protobufjs@7.5.4, secp256k1@5.0.1, utf-8-validate@5.0.10
Process completed with exit code 1.
```

Example failing run: https://github.com/hyperlane-xyz/v4-docs/actions/workflows/update-hyperlane-deps.yml

## Cause

#97 migrated `scripts/` to pnpm 11. pnpm 11 refuses to install when dependencies request post-install build scripts unless each one is explicitly allowed or denied via `allowBuilds` in `pnpm-workspace.yaml`. Locally pnpm generates a placeholder template for this file, but it was never filled in and committed — so every fresh CI checkout fails. The first scheduled run after #97 merged is the first failure.

(The sibling `update-agent-tags` workflow is unaffected — it doesn't run `pnpm install`.)

## Fix

Commit `scripts/pnpm-workspace.yaml` with all six packages denied. They are optional native/perf builds (websocket helpers, crypto acceleration) that the docs generation scripts don't need — the pure-JS fallbacks are used, same as in every successful run before the pnpm 11 migration.

## Verification

Reproduced and verified locally with pnpm `11.1.3` (identical to CI, pinned via `packageManager`):

- Without this file: `pnpm install --no-frozen-lockfile` exits 1 with the same `ERR_PNPM_IGNORED_BUILDS` error as CI
- With this file: install exits 0
- `node generate-all.js` then completes successfully with no diff to generated docs (versions unchanged)

## After merge

The Monday 9 AM UTC scheduled run will open the catch-up bot PR (SDK 35.2.0, Registry 25.3.0, regenerated chain data) for normal review — the workflow only opens PRs, never pushes to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)