### PR TITLE
ci: request edakturk14 as reviewer on dependency-update PRs

### DIFF
--- a/.github/workflows/update-hyperlane-deps.yml
+++ b/.github/workflows/update-hyperlane-deps.yml
@@ -115,12 +115,14 @@ jobs:
                 --base main \
                 --head ci/update-hl-deps \
                 --title "$PR_TITLE" \
-                --body "$PR_BODY"
+                --body "$PR_BODY" \
+                --reviewer edakturk14
             else
               echo "Pull request already exists. Updating title and description..."
               gh pr edit ci/update-hl-deps \
                 --title "$PR_TITLE" \
-                --body "$PR_BODY"
+                --body "$PR_BODY" \
+                --add-reviewer edakturk14
             fi
           else
             echo "No changes detected. Skipping PR creation."


### PR DESCRIPTION
## What

The weekly `update-hyperlane-deps` workflow now requests **@edakturk14** as a reviewer on the PR it opens, so you get a review-request email and can approve directly.

- `gh pr create` → adds `--reviewer edakturk14`
- `gh pr edit` (PR already exists) → adds `--add-reviewer edakturk14`

## Testing

- YAML parses cleanly.
- Ran the exact `gh pr edit --add-reviewer edakturk14` command against live PR #106 — succeeded, reviewer confirmed added. So the token's `pull-requests: write` permission covers requesting reviewers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)