### PR TITLE
docs: add In Progress removal chains to deprecated chains

### DIFF
--- a/.github/workflows/update-hyperlane-deps.yml
+++ b/.github/workflows/update-hyperlane-deps.yml
@@ -115,12 +115,14 @@ jobs:
                 --base main \
                 --head ci/update-hl-deps \
                 --title "$PR_TITLE" \
-                --body "$PR_BODY"
+                --body "$PR_BODY" \
+                --reviewer edakturk14
             else
               echo "Pull request already exists. Updating title and description..."
               gh pr edit ci/update-hl-deps \
                 --title "$PR_TITLE" \
-                --body "$PR_BODY"
+                --body "$PR_BODY" \
+                --add-reviewer edakturk14
             fi
           else
             echo "No changes detected. Skipping PR creation."

--- a/docs/reference/deprecated-chains.mdx
+++ b/docs/reference/deprecated-chains.mdx
@@ -13,46 +13,60 @@ Abacus Works is winding down its [Relayer](/docs/protocol/agents/relayer) and [V
   If you're building on any of these chains, plan your migration before the last supported date. After the listed date, Abacus Works will no longer operate agents for that chain. To take over agent operations, refer to the [Validator](/docs/operate/validators/run-validators) and [Relayer](/docs/operate/relayer/run-relayer) guides.
 </Warning>
 
-| Chain         | Domain ID  | Chain ID   | Last Supported Date |
-|---------------|------------|------------|---------------------|
-| Arbitrum Nova | 42170      | 42170      | May 10, 2026        |
-| Artela        | 11820      | 11820      | May 10, 2026        |
-| Astar         | 592        | 592        | July 10, 2026       |
-| Aurora        | 1313161554 | 1313161554 | May 10, 2026        |
-| B² Network    | 223        | 223        | May 10, 2026        |
-| B3            | 8333       | 8333       | May 10, 2026        |
-| Chiliz        | 1000088888 | 88888      | July 10, 2026       |
-| Degen         | 666666666  | 666666666  | May 10, 2026        |
-| Dogechain     | 2000       | 2000       | May 10, 2026        |
-| Endurance     | 648        | 648        | June 7, 2026        |
-| Everclear     | 25327      | 25327      | May 10, 2026        |
-| Fantom Opera  | 250        | 250        | May 10, 2026        |
-| Fluence       | 9999999    | 9999999    | May 10, 2026        |
-| Harmony One   | 1666600000 | 1666600000 | May 10, 2026        |
-| Incentiv      | 24101      | 24101      | July 10, 2026       |
-| Lit Chain     | 175200     | 175200     | June 16, 2026       |
-| Manta Pacific | 169        | 169        | July 10, 2026       |
-| Merlin        | 4200       | 4200       | May 10, 2026        |
-| MilkyWay      | 1835625579 | milkyway   | May 10, 2026        |
-| Miraclechain  | 92278      | 92278      | June 29, 2026       |
-| Molten        | 360        | 360        | June 1, 2026        |
-| Moonbeam      | 1284       | 1284       | May 10, 2026        |
-| Neutron       | 1853125230 | neutron-1  | March 14, 2026      |
-| Ontology      | 58         | 58         | July 10, 2026       |
-| Polygon zkEVM | 1101       | 1101       | May 10, 2026        |
-| Polynomial    | 1000008008 | 8008       | May 10, 2026        |
-| Redstone      | 690        | 690        | May 25, 2026        |
-| Scroll        | 534352     | 534352     | May 10, 2026        |
-| Sophon        | 50104      | 50104      | May 20, 2026        |
-| Story Mainnet | 1514       | 1514       | May 10, 2026        |
-| Stride        | 745        | stride-1   | July 10, 2026       |
-| Superposition | 1000055244 | 55244      | May 10, 2026        |
-| Swellchain    | 1923       | 1923       | June 28, 2026       |
-| Tangle        | 5845       | 5845       | May 10, 2026        |
-| Torus         | 21000      | 21000      | July 10, 2026       |
-| XRPL EVM      | 1440000    | 1440000    | July 10, 2026       |
-| Zero Network  | 543210     | 543210     | June 1, 2026        |
-| Zircuit       | 48900      | 48900      | July 10, 2026       |
-| Zora          | 7777777    | 7777777    | May 10, 2026        |
+| Chain                 | Domain ID  | Chain ID    | Last Supported Date |
+|-----------------------|------------|-------------|---------------------|
+| Ancient8              | 888888888  | 888888888   | July 16, 2026       |
+| Arbitrum Nova         | 42170      | 42170       | May 10, 2026        |
+| Arcadia               | 4278608    | 4278608     | July 16, 2026       |
+| Artela                | 11820      | 11820       | May 10, 2026        |
+| Astar                 | 592        | 592         | July 10, 2026       |
+| Aurora                | 1313161554 | 1313161554  | May 10, 2026        |
+| B² Network            | 223        | 223         | May 10, 2026        |
+| B3                    | 8333       | 8333        | May 10, 2026        |
+| Chiliz                | 1000088888 | 88888       | July 10, 2026       |
+| Core                  | 1116       | 1116        | July 16, 2026       |
+| Cyber                 | 7560       | 7560        | July 16, 2026       |
+| Degen                 | 666666666  | 666666666   | May 10, 2026        |
+| Dogechain             | 2000       | 2000        | May 10, 2026        |
+| Endurance             | 648        | 648         | June 7, 2026        |
+| Everclear             | 25327      | 25327       | May 10, 2026        |
+| Fantom Opera          | 250        | 250         | May 10, 2026        |
+| Flare                 | 14         | 14          | July 16, 2026       |
+| Fluence               | 9999999    | 9999999     | May 10, 2026        |
+| Fuse                  | 122        | 122         | July 16, 2026       |
+| Gravity Alpha Mainnet | 1625       | 1625        | July 16, 2026       |
+| Harmony One           | 1666600000 | 1666600000  | May 10, 2026        |
+| Incentiv              | 24101      | 24101       | July 10, 2026       |
+| Kaia                  | 8217       | 8217        | July 16, 2026       |
+| Lit Chain             | 175200     | 175200      | June 16, 2026       |
+| Manta Pacific         | 169        | 169         | July 10, 2026       |
+| Merlin                | 4200       | 4200        | May 10, 2026        |
+| MilkyWay              | 1835625579 | milkyway    | May 10, 2026        |
+| Miraclechain          | 92278      | 92278       | June 29, 2026       |
+| Molten                | 360        | 360         | June 1, 2026        |
+| Moonbeam              | 1284       | 1284        | May 10, 2026        |
+| Neutron               | 1853125230 | neutron-1   | March 14, 2026      |
+| Ontology              | 58         | 58          | July 10, 2026       |
+| opBNB                 | 204        | 204         | July 16, 2026       |
+| Orderly L2            | 291        | 291         | July 16, 2026       |
+| Polygon zkEVM         | 1101       | 1101        | May 10, 2026        |
+| Polynomial            | 1000008008 | 8008        | May 10, 2026        |
+| RARI Chain            | 1000012617 | 1380012617  | July 16, 2026       |
+| Redstone              | 690        | 690         | May 25, 2026        |
+| Scroll                | 534352     | 534352      | May 10, 2026        |
+| Shibarium             | 109        | 109         | July 16, 2026       |
+| Sophon                | 50104      | 50104       | May 20, 2026        |
+| Story Mainnet         | 1514       | 1514        | May 10, 2026        |
+| Stride                | 745        | stride-1    | July 10, 2026       |
+| Superposition         | 1000055244 | 55244       | May 10, 2026        |
+| Swellchain            | 1923       | 1923        | June 28, 2026       |
+| Tangle                | 5845       | 5845        | May 10, 2026        |
+| Torus                 | 21000      | 21000       | July 10, 2026       |
+| Xai                   | 660279     | 660279      | July 16, 2026       |
+| XRPL EVM              | 1440000    | 1440000     | July 10, 2026       |
+| Zero Network          | 543210     | 543210      | June 1, 2026        |
+| ZetaChain             | 7000       | 7000        | July 16, 2026       |
+| Zircuit               | 48900      | 48900       | July 10, 2026       |
+| Zora                  | 7777777    | 7777777     | May 10, 2026        |
 
 *Chain and domain IDs sourced from the [Hyperlane Registry](https://github.com/hyperlane-xyz/hyperlane-registry).*


### PR DESCRIPTION
## What

Adds 14 chains marked **In Progress** in the H1 2026 Chain Removals - Mainnet Linear project that were missing from `docs/reference/deprecated-chains.mdx`:

Ancient8, Arcadia, Core, Cyber, Flare, Fuse, Gravity Alpha Mainnet, Kaia, opBNB, Orderly L2, RARI Chain, Shibarium, Xai, ZetaChain.

## Details

- **Last Supported Date**: July 16, 2026 for all 14. None of these issues have a due date in Linear, so this date was provided manually — adjust if any chain needs a different actual date.
- Domain/Chain IDs sourced from the Hyperlane Registry (v25.3.0).
- Display names use registry `displayName` (e.g. `Core`, `Gravity Alpha Mainnet`, `Orderly L2`).
- Rows inserted in alphabetical order.
- The other 18 In Progress chains were already listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)