### PR TITLE
docs: remove Arcadia from deprecated chains

### DIFF
--- a/docs/reference/deprecated-chains.mdx
+++ b/docs/reference/deprecated-chains.mdx
@@ -17,7 +17,6 @@ Abacus Works is winding down its [Relayer](/docs/protocol/agents/relayer) and [V
 |-----------------------|------------|-------------|---------------------|
 | Ancient8              | 888888888  | 888888888   | July 16, 2026       |
 | Arbitrum Nova         | 42170      | 42170       | May 10, 2026        |
-| Arcadia               | 4278608    | 4278608     | July 16, 2026       |
 | Artela                | 11820      | 11820       | May 10, 2026        |
 | Astar                 | 592        | 592         | July 10, 2026       |
 | Aurora                | 1313161554 | 1313161554  | May 10, 2026        |


### PR DESCRIPTION
## What

Removes **Arcadia** (Domain/Chain ID `4278608`) from `docs/reference/deprecated-chains.mdx`.

## Why

Arcadia is no longer being deprecated — it was removed from the H1 2026 Chain Removals - Mainnet Linear project. It was added to the page in #108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)