### PR TITLE
docs(ecosystem): add OpenChainBench benchmarks reference

### DIFF
--- a/docs/ecosystem.mdx
+++ b/docs/ecosystem.mdx
@@ -54,6 +54,22 @@ Hyperlane provides the base layer for interoperability. This page shows what's p
 
 ---
 
+## Analytics & Benchmarks
+
+<CardGroup cols={2}>
+  <Card
+    title="OpenChainBench"
+    icon="chart-simple"
+    href="https://openchainbench.com/benchmarks/cross-chain-messaging-latency"
+  >
+    Independent open-source benchmark tracking end-to-end message delivery
+    latency across Hyperlane and other cross-chain messaging protocols.
+    Data is CC BY 4.0, methodology is public.
+  </Card>
+</CardGroup>
+
+---
+
 ## Custom VM Implementations
 
 Hyperlane supports chains with non-EVM execution environments through bespoke VM implementations. These integrations include the full Hyperlane stack: [Mailbox](/docs/protocol/core/mailbox), [Hyperlane Warp Routes](/docs/protocol/warp-routes/warp-routes-overview), [ISMs](/docs/protocol/ISM/modular-security), and [agent infrastructure](/docs/protocol/agents/overview).

--- a/docs/ecosystem.mdx
+++ b/docs/ecosystem.mdx
@@ -60,10 +60,10 @@ Hyperlane provides the base layer for interoperability. This page shows what's p
   <Card
     title="OpenChainBench"
     icon="chart-simple"
-    href="https://openchainbench.com/benchmarks/cross-chain-messaging-latency"
+    href="https://openchainbench.com/benchmarks/hyperlane-message-latency"
   >
-    Independent open-source benchmark tracking end-to-end message delivery
-    latency across Hyperlane and other cross-chain messaging protocols.
+    Independent open-source benchmark tracking Hyperlane end-to-end
+    message delivery latency by source chain across 8 supported chains.
     Data is CC BY 4.0, methodology is public.
   </Card>
 </CardGroup>


### PR DESCRIPTION
Adds a new "Analytics & Benchmarks" section to the Ecosystem page featuring OpenChainBench (https://openchainbench.com), an independent open-source benchmark platform.

OCB benchmarks Hyperlane end-to-end message-delivery latency by source chain across 8 supported chains (Celo, Polygon, Arbitrum, BNB Chain, Ink, Unichain, Sonic, Avalanche): https://openchainbench.com/benchmarks/hyperlane-message-latency

Data is licensed CC BY 4.0, methodology is public, harnesses are open source. Follows the existing CardGroup pattern used on the same page.

Happy to iterate on wording or placement if the maintainers prefer a different section.