### PR TITLE
docs: add August 2026 removal chains to deprecated chains

### DIFF
--- a/docs/reference/deprecated-chains.mdx
+++ b/docs/reference/deprecated-chains.mdx
@@ -20,8 +20,11 @@ Abacus Works is winding down its [Relayer](/docs/protocol/agents/relayer) and [V
 | Artela                | 11820      | 11820       | May 10, 2026        |
 | Astar                 | 592        | 592         | July 10, 2026       |
 | Aurora                | 1313161554 | 1313161554  | May 10, 2026        |
-| B² Network            | 223        | 223         | May 10, 2026        |
+| B² Network            | 223        | 223         | August 10, 2026     |
 | B3                    | 8333       | 8333        | May 10, 2026        |
+| Bitlayer              | 200901     | 200901      | August 10, 2026     |
+| Boba Mainnet          | 288        | 288         | August 10, 2026     |
+| Botanix               | 3637       | 3637        | July 31, 2026       |
 | Chiliz                | 1000088888 | 88888       | July 10, 2026       |
 | Core                  | 1116       | 1116        | July 16, 2026       |
 | Cyber                 | 7560       | 7560        | July 16, 2026       |
@@ -29,12 +32,16 @@ Abacus Works is winding down its [Relayer](/docs/protocol/agents/relayer) and [V
 | Dogechain             | 2000       | 2000        | May 10, 2026        |
 | Endurance             | 648        | 648         | June 7, 2026        |
 | Everclear             | 25327      | 25327       | May 10, 2026        |
+| EVM on Flow           | 1000000747 | 747         | August 10, 2026     |
 | Fantom Opera          | 250        | 250         | May 10, 2026        |
 | Flare                 | 14         | 14          | July 16, 2026       |
 | Fluence               | 9999999    | 9999999     | May 10, 2026        |
+| Forma                 | 984122     | 984122      | October 31, 2026    |
 | Fuse                  | 122        | 122         | July 16, 2026       |
 | Gravity Alpha Mainnet | 1625       | 1625        | July 16, 2026       |
 | Harmony One           | 1666600000 | 1666600000  | May 10, 2026        |
+| Hashkey               | 177        | 177         | August 10, 2026     |
+| Hemi Network          | 43111      | 43111       | August 10, 2026     |
 | Incentiv              | 24101      | 24101       | July 10, 2026       |
 | Kaia                  | 8217       | 8217        | July 16, 2026       |
 | Lit Chain             | 175200     | 175200      | June 16, 2026       |
@@ -44,16 +51,23 @@ Abacus Works is winding down its [Relayer](/docs/protocol/agents/relayer) and [V
 | Miraclechain          | 92278      | 92278       | June 29, 2026       |
 | Molten                | 360        | 360         | June 1, 2026        |
 | Moonbeam              | 1284       | 1284        | May 10, 2026        |
+| Morph                 | 2818       | 2818        | August 10, 2026     |
 | Neutron               | 1853125230 | neutron-1   | March 14, 2026      |
+| Nibiru                | 6900       | 6900        | August 10, 2026     |
+| Noble                 | 1313817164 | noble-1     | August 10, 2026     |
 | Ontology              | 58         | 58          | July 10, 2026       |
 | opBNB                 | 204        | 204         | July 16, 2026       |
+| Oort                  | 970        | 970         | August 14, 2026     |
 | Orderly L2            | 291        | 291         | July 16, 2026       |
+| Peaq                  | 3338       | 3338        | August 10, 2026     |
+| Plume                 | 98866      | 98866       | August 10, 2026     |
 | Polygon zkEVM         | 1101       | 1101        | May 10, 2026        |
 | Polynomial            | 1000008008 | 8008        | May 10, 2026        |
 | RARI Chain            | 1000012617 | 1380012617  | July 16, 2026       |
 | Redstone              | 690        | 690         | May 25, 2026        |
 | Scroll                | 534352     | 534352      | May 10, 2026        |
 | Shibarium             | 109        | 109         | July 16, 2026       |
+| Sonic                 | 146        | 146         | August 10, 2026     |
 | Sophon                | 50104      | 50104       | May 20, 2026        |
 | Story Mainnet         | 1514       | 1514        | May 10, 2026        |
 | Stride                | 745        | stride-1    | July 10, 2026       |

--- a/docs/reference/deprecated-chains.mdx
+++ b/docs/reference/deprecated-chains.mdx
@@ -64,6 +64,7 @@ Abacus Works is winding down its [Relayer](/docs/protocol/agents/relayer) and [V
 | Polygon zkEVM         | 1101       | 1101        | May 10, 2026        |
 | Polynomial            | 1000008008 | 8008        | May 10, 2026        |
 | RARI Chain            | 1000012617 | 1380012617  | July 16, 2026       |
+| Reactive Mainnet      | 1597       | 1597        | August 10, 2026     |
 | Redstone              | 690        | 690         | May 25, 2026        |
 | Scroll                | 534352     | 534352      | May 10, 2026        |
 | Shibarium             | 109        | 109         | July 16, 2026       |


### PR DESCRIPTION
Adds 15 chains scheduled for Abacus Works agent removal to the [Deprecated Chains](docs/reference/deprecated-chains.mdx) page.

| Chain | Domain ID | Chain ID | Last Supported Date |
|---|---|---|---|
| Bitlayer | 200901 | 200901 | August 10, 2026 |
| Boba Mainnet | 288 | 288 | August 10, 2026 |
| Botanix | 3637 | 3637 | July 31, 2026 |
| EVM on Flow | 1000000747 | 747 | August 10, 2026 |
| Forma | 984122 | 984122 | October 31, 2026 |
| Hashkey | 177 | 177 | August 10, 2026 |
| Hemi Network | 43111 | 43111 | August 10, 2026 |
| Morph | 2818 | 2818 | August 10, 2026 |
| Nibiru | 6900 | 6900 | August 10, 2026 |
| Noble | 1313817164 | noble-1 | August 10, 2026 |
| Oort | 970 | 970 | August 14, 2026 |
| Peaq | 3338 | 3338 | August 10, 2026 |
| Plume | 98866 | 98866 | August 10, 2026 |
| Reactive Mainnet | 1597 | 1597 | August 10, 2026 |
| Sonic | 146 | 146 | August 10, 2026 |

Also updates **B² Network**'s last supported date from May 10, 2026 to August 10, 2026.

Chain and domain IDs sourced from the [Hyperlane Registry](https://github.com/hyperlane-xyz/hyperlane-registry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)