### PR TITLE
docs: add August 2026 removal chains to deprecated chains

### DIFF
--- a/docs/reference/deprecated-chains.mdx
+++ b/docs/reference/deprecated-chains.mdx
@@ -18,6 +18,7 @@ Abacus Works is winding down its [Relayer](/docs/protocol/agents/relayer) and [V
 | Ancient8              | 888888888  | 888888888   | July 16, 2026       |
 | AppChain              | 466        | 466         | August 21, 2026     |
 | Arbitrum Nova         | 42170      | 42170       | May 10, 2026        |
+| Arcadia               | 4278608    | 4278608     | August 18, 2026     |
 | Artela                | 11820      | 11820       | May 10, 2026        |
 | Astar                 | 592        | 592         | July 10, 2026       |
 | Aurora                | 1313161554 | 1313161554  | May 10, 2026        |

--- a/docs/reference/deprecated-chains.mdx
+++ b/docs/reference/deprecated-chains.mdx
@@ -16,6 +16,7 @@ Abacus Works is winding down its [Relayer](/docs/protocol/agents/relayer) and [V
 | Chain                 | Domain ID  | Chain ID    | Last Supported Date |
 |-----------------------|------------|-------------|---------------------|
 | Ancient8              | 888888888  | 888888888   | July 16, 2026       |
+| AppChain              | 466        | 466         | August 21, 2026     |
 | Arbitrum Nova         | 42170      | 42170       | May 10, 2026        |
 | Artela                | 11820      | 11820       | May 10, 2026        |
 | Astar                 | 592        | 592         | July 10, 2026       |
@@ -42,9 +43,11 @@ Abacus Works is winding down its [Relayer](/docs/protocol/agents/relayer) and [V
 | Harmony One           | 1666600000 | 1666600000  | May 10, 2026        |
 | Hashkey               | 177        | 177         | August 10, 2026     |
 | Hemi Network          | 43111      | 43111       | August 10, 2026     |
+| Immutable zkEVM       | 1000013371 | 13371       | August 14, 2026     |
 | Incentiv              | 24101      | 24101       | July 10, 2026       |
 | Kaia                  | 8217       | 8217        | July 16, 2026       |
 | Lit Chain             | 175200     | 175200      | June 16, 2026       |
+| Lumia Prism           | 1000073017 | 994873017   | August 14, 2026     |
 | Manta Pacific         | 169        | 169         | July 10, 2026       |
 | Merlin                | 4200       | 4200        | May 10, 2026        |
 | MilkyWay              | 1835625579 | milkyway    | May 10, 2026        |
@@ -66,14 +69,17 @@ Abacus Works is winding down its [Relayer](/docs/protocol/agents/relayer) and [V
 | RARI Chain            | 1000012617 | 1380012617  | July 16, 2026       |
 | Reactive Mainnet      | 1597       | 1597        | August 10, 2026     |
 | Redstone              | 690        | 690         | May 25, 2026        |
+| Ronin                 | 2020       | 2020        | August 14, 2026     |
 | Scroll                | 534352     | 534352      | May 10, 2026        |
 | Shibarium             | 109        | 109         | July 16, 2026       |
 | Sonic                 | 146        | 146         | August 10, 2026     |
+| SOON                  | 50075007   | 50075007    | August 14, 2026     |
 | Sophon                | 50104      | 50104       | May 20, 2026        |
 | Story Mainnet         | 1514       | 1514        | May 10, 2026        |
 | Stride                | 745        | stride-1    | July 10, 2026       |
 | Superposition         | 1000055244 | 55244       | May 10, 2026        |
 | Swellchain            | 1923       | 1923        | June 28, 2026       |
+| TAC                   | 239        | 239         | August 14, 2026     |
 | Tangle                | 5845       | 5845        | May 10, 2026        |
 | Torus                 | 21000      | 21000       | July 10, 2026       |
 | Xai                   | 660279     | 660279      | July 16, 2026       |

--- a/docs/reference/deprecated-chains.mdx
+++ b/docs/reference/deprecated-chains.mdx
@@ -83,7 +83,7 @@ Abacus Works is winding down its [Relayer](/docs/protocol/agents/relayer) and [V
 | TAC                   | 239        | 239         | August 14, 2026     |
 | Tangle                | 5845       | 5845        | May 10, 2026        |
 | Torus                 | 21000      | 21000       | July 10, 2026       |
-| Vana                  | 1480       | 1480        | August 7, 2026      |
+| Vana                  | 1480       | 1480        | July 29, 2026       |
 | Xai                   | 660279     | 660279      | July 16, 2026       |
 | XRPL EVM              | 1440000    | 1440000     | July 10, 2026       |
 | Zero Network          | 543210     | 543210      | June 1, 2026        |

--- a/docs/reference/deprecated-chains.mdx
+++ b/docs/reference/deprecated-chains.mdx
@@ -43,7 +43,7 @@ Abacus Works is winding down its [Relayer](/docs/protocol/agents/relayer) and [V
 | Harmony One           | 1666600000 | 1666600000  | May 10, 2026        |
 | Hashkey               | 177        | 177         | August 10, 2026     |
 | Hemi Network          | 43111      | 43111       | August 10, 2026     |
-| Immutable zkEVM       | 1000013371 | 13371       | August 14, 2026     |
+| Immutable zkEVM       | 1000013371 | 13371       | August 28, 2026     |
 | Incentiv              | 24101      | 24101       | July 10, 2026       |
 | Kaia                  | 8217       | 8217        | July 16, 2026       |
 | Lit Chain             | 175200     | 175200      | June 16, 2026       |
@@ -66,6 +66,7 @@ Abacus Works is winding down its [Relayer](/docs/protocol/agents/relayer) and [V
 | Plume                 | 98866      | 98866       | August 10, 2026     |
 | Polygon zkEVM         | 1101       | 1101        | May 10, 2026        |
 | Polynomial            | 1000008008 | 8008        | May 10, 2026        |
+| Prom                  | 227        | 227         | July 31, 2026       |
 | RARI Chain            | 1000012617 | 1380012617  | July 16, 2026       |
 | Reactive Mainnet      | 1597       | 1597        | August 10, 2026     |
 | Redstone              | 690        | 690         | May 25, 2026        |
@@ -82,6 +83,7 @@ Abacus Works is winding down its [Relayer](/docs/protocol/agents/relayer) and [V
 | TAC                   | 239        | 239         | August 14, 2026     |
 | Tangle                | 5845       | 5845        | May 10, 2026        |
 | Torus                 | 21000      | 21000       | July 10, 2026       |
+| Vana                  | 1480       | 1480        | August 7, 2026      |
 | Xai                   | 660279     | 660279      | July 16, 2026       |
 | XRPL EVM              | 1440000    | 1440000     | July 10, 2026       |
 | Zero Network          | 543210     | 543210      | June 1, 2026        |


### PR DESCRIPTION
Adds chains to `docs/reference/deprecated-chains.mdx` that were missing from the removal tracker, and corrects dates where Linear had changed.

| Chain | Domain ID | Chain ID | Last Supported Date |
|---|---|---|---|
| AppChain | 466 | 466 | August 21, 2026 |
| Arcadia | 4278608 | 4278608 | August 18, 2026 |
| Immutable zkEVM | 1000013371 | 13371 | August 28, 2026 |
| Lumia Prism | 1000073017 | 994873017 | August 14, 2026 |
| Ronin | 2020 | 2020 | August 14, 2026 |
| SOON | 50075007 | 50075007 | August 14, 2026 |
| TAC | 239 | 239 | August 14, 2026 |
| Vana | 1480 | 1480 | July 29, 2026 |
| Prom | 227 | 227 | July 31, 2026 |

Domain and chain IDs taken from the existing deployment address tables in this repo (`docs/reference/addresses/deployments/`). All entries and dates cross-checked against the Linear deprecation tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)