### PR TITLE
docs: add September 30 removal chains to deprecated chains

### DIFF
--- a/docs/reference/deprecated-chains.mdx
+++ b/docs/reference/deprecated-chains.mdx
@@ -24,7 +24,9 @@ Abacus Works is winding down its [Relayer](/docs/protocol/agents/relayer) and [V
 | Aurora                | 1313161554 | 1313161554  | May 10, 2026        |
 | B² Network            | 223        | 223         | August 10, 2026     |
 | B3                    | 8333       | 8333        | May 10, 2026        |
+| Berachain             | 80094      | 80094       | September 30, 2026  |
 | Bitlayer              | 200901     | 200901      | August 10, 2026     |
+| Blast                 | 81457      | 81457       | September 30, 2026  |
 | Boba Mainnet          | 288        | 288         | August 10, 2026     |
 | Botanix               | 3637       | 3637        | July 31, 2026       |
 | Chiliz                | 1000088888 | 88888       | July 10, 2026       |
@@ -50,6 +52,7 @@ Abacus Works is winding down its [Relayer](/docs/protocol/agents/relayer) and [V
 | Lit Chain             | 175200     | 175200      | June 16, 2026       |
 | Lumia Prism           | 1000073017 | 994873017   | August 14, 2026     |
 | Manta Pacific         | 169        | 169         | July 10, 2026       |
+| MegaETH               | 4326       | 4326        | September 30, 2026  |
 | Merlin                | 4200       | 4200        | May 10, 2026        |
 | MilkyWay              | 1835625579 | milkyway    | May 10, 2026        |
 | Miraclechain          | 92278      | 92278       | June 29, 2026       |
@@ -73,6 +76,7 @@ Abacus Works is winding down its [Relayer](/docs/protocol/agents/relayer) and [V
 | Redstone              | 690        | 690         | May 25, 2026        |
 | Ronin                 | 2020       | 2020        | August 14, 2026     |
 | Scroll                | 534352     | 534352      | May 10, 2026        |
+| Sei                   | 1329       | 1329        | September 30, 2026  |
 | Shibarium             | 109        | 109         | July 16, 2026       |
 | Sonic                 | 146        | 146         | August 10, 2026     |
 | SOON                  | 50075007   | 50075007    | August 14, 2026     |
@@ -82,6 +86,7 @@ Abacus Works is winding down its [Relayer](/docs/protocol/agents/relayer) and [V
 | Superposition         | 1000055244 | 55244       | May 10, 2026        |
 | Swellchain            | 1923       | 1923        | June 28, 2026       |
 | TAC                   | 239        | 239         | August 14, 2026     |
+| Taiko                 | 167000     | 167000      | September 30, 2026  |
 | Tangle                | 5845       | 5845        | May 10, 2026        |
 | Torus                 | 21000      | 21000       | July 10, 2026       |
 | Vana                  | 1480       | 1480        | July 29, 2026       |


### PR DESCRIPTION
Adds five chains to `docs/reference/deprecated-chains.mdx`, all with a last supported date of September 30, 2026.

| Chain | Domain ID | Chain ID | Last Supported Date |
|---|---|---|---|
| Berachain | 80094 | 80094 | September 30, 2026 |
| Blast | 81457 | 81457 | September 30, 2026 |
| MegaETH | 4326 | 4326 | September 30, 2026 |
| Sei | 1329 | 1329 | September 30, 2026 |
| Taiko | 167000 | 167000 | September 30, 2026 |

Domain and chain IDs taken from the existing deployment address tables in this repo (`docs/reference/addresses/deployments/mailbox.mdx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)