### PR TITLE
docs: add governance timelock guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -163,6 +163,7 @@
                     "pages": [
                       "docs/guides/production/warp-route-deployment/remove-trusted-relayer",
                       "docs/guides/production/warp-route-deployment/transfer-warp-route-ownership",
+                      "docs/guides/production/warp-route-deployment/govern-with-timelocks",
                       "docs/guides/production/warp-route-deployment/configure-rate-limit-ism",
                       "docs/guides/production/warp-route-deployment/configure-pausable-ism"
                     ]

--- a/docs/guides/production/prod-overview.mdx
+++ b/docs/guides/production/prod-overview.mdx
@@ -52,6 +52,15 @@ Transfer ownership of the HWR to the designated production owner. This step ensu
 
 </Card>
     <Card
+      title="Govern with Timelocks"
+      icon="clock"
+      href="./warp-route-deployment/govern-with-timelocks"
+    >
+      Put a timelock between governance proposals and execution. Timelocks give
+      route owners, chains, and integrators time to inspect and cancel risky
+      owner actions before they take effect.
+    </Card>
+    <Card
       title="Configure Rate Limit ISM"
       icon="link"
       href="./warp-route-deployment/configure-rate-limit-ism"

--- a/docs/guides/production/warp-route-deployment/govern-with-timelocks.mdx
+++ b/docs/guides/production/warp-route-deployment/govern-with-timelocks.mdx
@@ -1,0 +1,190 @@
+---
+title: "Govern with Timelocks"
+description: "Use OpenZeppelin timelocks to make Warp Route and chain governance safer"
+---
+
+Hyperlane contracts are commonly `Ownable` because teams need a way to expand to new chains, enroll routers, update ISMs, change hooks, tune rate limits, pause routes, or transfer ownership. For production systems, direct ownership by a hot key or even a multisig can still be risky: if the owner path is compromised, an attacker can execute privileged changes immediately.
+
+A governance timelock puts a delay between proposing an owner action and executing it. This gives your team, integrators, and monitors time to inspect the action and cancel it before it takes effect.
+
+## Who should use this
+
+Use timelock governance if you operate:
+
+- A Warp Route with meaningful TVL.
+- A chain's Hyperlane Mailbox or core deployment.
+- A route integrated by external protocols, lending markets, or risk teams.
+- A multisig or ICA setup where signers are not expected to make urgent owner changes.
+
+Timelocks are especially useful when governance actions are important but rarely time-sensitive.
+
+## How OpenZeppelin timelocks work
+
+Hyperlane tooling uses OpenZeppelin's [`TimelockController`](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/governance/TimelockController.sol). The timelock contract becomes the owner of the governed contract.
+
+An owner action then has two phases:
+
+1. A proposer schedules the exact call on the timelock.
+2. After `minimumDelay`, anyone with executor rights can execute that exact call.
+
+The operation includes the target contract, calldata, ETH value, predecessor, salt, and delay. The timelock hashes these fields into an operation ID, so the executed transaction must match what was scheduled.
+
+## Roles
+
+| Role | What it can do | Recommended setup |
+|---|---|---|
+| `PROPOSER_ROLE` | Schedule operations | Governance Safe on the owner chain, or its ICA on remote chains |
+| `EXECUTOR_ROLE` | Execute ready operations | `address(0)` for permissionless execution |
+| `CANCELLER_ROLE` | Cancel pending operations | Operational vetoer, deployer key, security council, or governance-controlled address |
+| `TIMELOCK_ADMIN_ROLE` | Manage roles | Use carefully; avoid leaving this on a hot deployer key |
+
+Permissionless execution is usually desirable. Once a valid proposal has waited through the delay, anyone can execute it, so liveness does not depend on the proposer returning online.
+
+## Why it is safer
+
+Without a timelock, a compromised owner can immediately change sensitive configuration. For a Warp Route, that could mean replacing the ISM, changing ownership, altering limits, or weakening safety controls.
+
+With a timelock:
+
+- The malicious or mistaken action is visible before execution.
+- Watchers can decode and review the scheduled calldata.
+- A configured canceller can veto the operation.
+- Integrators get time to react before the change takes effect.
+- ICA-based governance is less brittle because a bad ICA message can schedule an action, but cannot execute it immediately.
+
+Timelocks do not replace good key management, good ISM design, or monitoring. They add an observation and cancellation window around owner actions.
+
+## Hyperlane setup
+
+A typical setup uses one governance Safe on an owner chain, usually Ethereum, and one timelock on each chain where contracts are governed.
+
+```mermaid
+flowchart LR
+  subgraph OwnerChain["Owner chain, usually Ethereum"]
+    Safe["Governance Safe"]
+    OwnerTimelock["Owner-chain TimelockController"]
+    OwnerContract["Governed contract"]
+  end
+
+  subgraph RemoteChain["Remote EVM chain"]
+    ICA["Interchain Account"]
+    RemoteTimelock["Remote TimelockController"]
+    RemoteContract["Governed contract"]
+  end
+
+  Safe -->|"schedule directly"| OwnerTimelock
+  OwnerTimelock -->|"owns and later executes"| OwnerContract
+
+  Safe -->|"send ICA message"| ICA
+  ICA -->|"schedule"| RemoteTimelock
+  RemoteTimelock -->|"owns and later executes"| RemoteContract
+
+  Canceller["Canceller / vetoer"] -. "cancel pending operation" .-> OwnerTimelock
+  Canceller -. "cancel pending operation" .-> RemoteTimelock
+  Executor["Anyone, after delay"] -. "execute ready operation" .-> OwnerTimelock
+  Executor -. "execute ready operation" .-> RemoteTimelock
+```
+
+On the owner chain:
+
+- The governed contract is owned by the timelock on that same chain.
+- The governance Safe has `PROPOSER_ROLE` on that timelock.
+- The Safe schedules actions directly on the timelock.
+
+On each remote EVM chain:
+
+- The governed contract is owned by a timelock on that remote chain.
+- The proposer is an Interchain Account (ICA) on that remote chain.
+- That ICA is controlled by the governance Safe on the owner chain.
+- The Safe sends an ICA message, and the ICA schedules the action on the remote timelock.
+
+The flow for a remote owner action is:
+
+1. The owner-chain Safe creates an ICA transaction.
+2. The ICA schedules the action on the remote chain's timelock.
+3. The action waits for the configured delay, which should be at least 1 day.
+4. If the proposal is bad, a canceller calls `cancel`.
+5. If the proposal is valid, anyone executes the queued operation after the delay.
+
+For Ethereum-local actions, the Safe can schedule directly on the Ethereum timelock without using an ICA.
+
+## Example
+
+Suppose a Warp Route on Base is owned by a Base timelock. The timelock has:
+
+- `PROPOSER_ROLE`: the Ethereum Safe's ICA on Base.
+- `EXECUTOR_ROLE`: `address(0)`.
+- `CANCELLER_ROLE`: an operational vetoer or security council address.
+- `minimumDelay`: at least `86400` seconds.
+
+To update the route ISM, the Ethereum Safe does not call the route directly. It sends an ICA call that schedules:
+
+```solidity
+warpRoute.setInterchainSecurityModule(newIsm);
+```
+
+on the Base timelock. The call can only be executed after the delay, and only if it has not been cancelled.
+
+## Submitter strategy
+
+When you deploy or update your own Warp Route with the Hyperlane CLI, pass a submitter strategy so the CLI knows how to submit owner transactions. If your route is owned by a timelock, use a `timelockController` submitter strategy.
+
+The strategy wraps route updates in `scheduleBatch` and returns the later `executeBatch` transaction. This lets `warp apply` propose the update through the timelock instead of trying to call the owned contract directly.
+
+Example remote-chain strategy:
+
+```yaml
+base:
+  submitter:
+    type: timelockController
+    chain: base
+    timelockAddress: "0x..."
+    proposerSubmitter:
+      type: interchainAccount
+      chain: ethereum
+      destinationChain: base
+      owner: "0x..." # Ethereum Safe
+      internalSubmitter:
+        type: gnosisSafeTxBuilder
+        chain: ethereum
+        safeAddress: "0x..."
+        version: "1.0"
+```
+
+Example owner-chain strategy:
+
+```yaml
+ethereum:
+  submitter:
+    type: timelockController
+    chain: ethereum
+    timelockAddress: "0x..."
+    proposerSubmitter:
+      type: gnosisSafeTxBuilder
+      chain: ethereum
+      safeAddress: "0x..."
+      version: "1.0"
+```
+
+## What Hyperlane already provides
+
+The Hyperlane monorepo includes:
+
+- An OpenZeppelin `TimelockController` deployment wrapper.
+- SDK support for deploying and reading EVM timelocks.
+- Submitter support for `timelockController` strategies.
+- ICA submitter nesting, so a Safe can propose on remote timelocks through ICAs.
+- Scripts to list pending timelock operations and cancel them.
+
+Abacus Works and Regular governance configurations already use this pattern for many EVM chains: Ethereum uses a Safe-controlled timelock, and remote chains use ICA-proposed timelocks.
+
+## Operational guidance
+
+- Use a delay long enough for monitoring and human review. The minimum recommended delay is 1 day.
+- Keep execution permissionless unless you have a specific reason not to.
+- Give cancellation rights to parties that can respond quickly.
+- Monitor `CallScheduled`, `CallExecuted`, and `Cancelled` events on every timelock.
+- Document who can propose, who can cancel, and how emergency cancellation works.
+- Avoid using a timelock for actions that must execute immediately during an incident.
+
+For many teams, the recommended production owner is not a Safe directly, but a timelock whose proposer is the Safe or the Safe's ICA.

--- a/docs/guides/production/warp-route-deployment/govern-with-timelocks.mdx
+++ b/docs/guides/production/warp-route-deployment/govern-with-timelocks.mdx
@@ -3,7 +3,7 @@ title: "Govern with Timelocks"
 description: "Use OpenZeppelin timelocks to make Warp Route and chain governance safer"
 ---
 
-Hyperlane contracts are commonly `Ownable` because teams need a way to expand to new chains, enroll routers, update ISMs, change hooks, tune rate limits, pause routes, or transfer ownership. For production systems, direct ownership by a hot key or even a multisig can still be risky: if the owner path is compromised, an attacker can execute privileged changes immediately.
+Hyperlane contracts are commonly `Ownable` because teams need a way to expand to new chains, enroll routers, update ISMs, change Hooks, tune rate limits, pause routes, or transfer ownership. For production systems, direct ownership by a hot key or even a multisig can still be risky: if the owner path is compromised, an attacker can execute privileged changes immediately.
 
 A governance timelock puts a delay between proposing an owner action and executing it. This gives your team, integrators, and monitors time to inspect the action and cancel it before it takes effect.
 
@@ -20,12 +20,12 @@ Timelocks are especially useful when governance actions are important but rarely
 
 ## How OpenZeppelin timelocks work
 
-Hyperlane tooling uses OpenZeppelin's [`TimelockController`](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/governance/TimelockController.sol). The timelock contract becomes the owner of the governed contract.
+Hyperlane tooling uses OpenZeppelin's [`TimelockController`](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v4.7.0/contracts/governance/TimelockController.sol), exposed through Hyperlane's [`TimelockController` wrapper](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/solidity/contracts/upgrade/TimelockController.sol). The timelock contract becomes the owner of the governed contract.
 
 An owner action then has two phases:
 
 1. A proposer schedules the exact call on the timelock.
-2. After `minimumDelay`, anyone with executor rights can execute that exact call.
+2. After `minDelay`, anyone with executor rights can execute that exact call.
 
 The operation includes the target contract, calldata, ETH value, predecessor, salt, and delay. The timelock hashes these fields into an operation ID, so the executed transaction must match what was scheduled.
 
@@ -39,6 +39,8 @@ The operation includes the target contract, calldata, ETH value, predecessor, sa
 | `TIMELOCK_ADMIN_ROLE` | Manage roles | Use carefully; avoid leaving this on a hot deployer key |
 
 Permissionless execution is usually desirable. Once a valid proposal has waited through the delay, anyone can execute it, so liveness does not depend on the proposer returning online.
+
+In the OpenZeppelin v4.7 implementation used by Hyperlane, initial proposers also receive `CANCELLER_ROLE`. Account for that when choosing proposers and vetoers.
 
 ## Why it is safer
 
@@ -102,7 +104,7 @@ The flow for a remote owner action is:
 
 1. The owner-chain Safe creates an ICA transaction.
 2. The ICA schedules the action on the remote chain's timelock.
-3. The action waits for the configured delay, which should be at least 1 day.
+3. The action waits for the configured delay. Hyperlane recommends at least 1 day as a production baseline.
 4. If the proposal is bad, a canceller calls `cancel`.
 5. If the proposal is valid, anyone executes the queued operation after the delay.
 
@@ -115,21 +117,17 @@ Suppose a Warp Route on Base is owned by a Base timelock. The timelock has:
 - `PROPOSER_ROLE`: the Ethereum Safe's ICA on Base.
 - `EXECUTOR_ROLE`: `address(0)`.
 - `CANCELLER_ROLE`: an operational vetoer or security council address.
-- `minimumDelay`: at least `86400` seconds.
+- `minDelay`: at least `86400` seconds, matching Hyperlane's 1-day production baseline.
 
-To update the route ISM, the Ethereum Safe does not call the route directly. It sends an ICA call that schedules:
-
-```solidity
-warpRoute.setInterchainSecurityModule(newIsm);
-```
-
-on the Base timelock. The call can only be executed after the delay, and only if it has not been cancelled.
+To update the route ISM, the Ethereum Safe does not call the route directly. It sends an ICA call that schedules the route's `setInterchainSecurityModule(newIsm)` call on the Base timelock. The call can only be executed after the delay, and only if it has not been cancelled.
 
 ## Submitter strategy
 
 When you deploy or update your own Warp Route with the Hyperlane CLI, pass a submitter strategy so the CLI knows how to submit owner transactions. If your route is owned by a timelock, use a `timelockController` submitter strategy.
 
 The strategy wraps route updates in `scheduleBatch` and returns the later `executeBatch` transaction. This lets `warp apply` propose the update through the timelock instead of trying to call the owned contract directly.
+
+The type names below match the current SDK submitter types: [`timelockController`, `interchainAccount`, and `gnosisSafeTxBuilder`](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/typescript/sdk/src/providers/transactions/submitter/TxSubmitterTypes.ts). The `timelockAddress` and `proposerSubmitter` keys come from the [EVM timelock submitter schema](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/typescript/sdk/src/providers/transactions/submitter/ethersV5/types.ts), and the `internalSubmitter` nesting with Safe Tx Builder `version: '1.0'` matches the current [oUSDT strategy config](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/typescript/infra/config/environments/mainnet3/warp/strategies/ousdt.yaml).
 
 Example remote-chain strategy:
 
@@ -170,17 +168,17 @@ ethereum:
 
 The Hyperlane monorepo includes:
 
-- An OpenZeppelin `TimelockController` deployment wrapper.
-- SDK support for deploying and reading EVM timelocks.
-- Submitter support for `timelockController` strategies.
-- ICA submitter nesting, so a Safe can propose on remote timelocks through ICAs.
-- Scripts to list pending timelock operations and cancel them.
+- An OpenZeppelin [`TimelockController` deployment wrapper](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/solidity/contracts/upgrade/TimelockController.sol).
+- SDK support for [deploying](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/typescript/sdk/src/timelock/evm/EvmTimelockDeployer.ts) and [reading](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/typescript/sdk/src/timelock/evm/EvmTimelockReader.ts) EVM timelocks.
+- Submitter support for [`timelockController` strategies](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5TimelockSubmitter.ts).
+- ICA submitter nesting, so a Safe can propose on remote timelocks through ICAs. See the [oUSDT strategy generator](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/typescript/infra/scripts/warp-routes/ousdt/update-submitter-strategy.ts) and [oUSDT strategy config](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/typescript/infra/config/environments/mainnet3/warp/strategies/ousdt.yaml).
+- Scripts to [list pending timelock operations](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/typescript/infra/scripts/timelocks/get-pending-txs.ts) and [cancel them](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/typescript/infra/scripts/timelocks/cancel-pending-txs.ts).
 
-Abacus Works and Regular governance configurations already use this pattern for many EVM chains: Ethereum uses a Safe-controlled timelock, and remote chains use ICA-proposed timelocks.
+Abacus Works and Hyperlane "Regular" governance (also called Multisig A in the infra config) already use this pattern for many EVM chains: Ethereum uses a Safe-controlled timelock, and remote chains use ICA-proposed timelocks. See the [Abacus Works timelock config](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/typescript/infra/config/environments/mainnet3/governance/timelock/aw.ts) and [Regular timelock config](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/typescript/infra/config/environments/mainnet3/governance/timelock/regular.ts).
 
 ## Operational guidance
 
-- Use a delay long enough for monitoring and human review. The minimum recommended delay is 1 day.
+- Use a delay long enough for monitoring and human review. Hyperlane's minimum recommended production baseline is 1 day.
 - Keep execution permissionless unless you have a specific reason not to.
 - Give cancellation rights to parties that can respond quickly.
 - Monitor `CallScheduled`, `CallExecuted`, and `Cancelled` events on every timelock.

--- a/docs/guides/production/warp-route-deployment/govern-with-timelocks.mdx
+++ b/docs/guides/production/warp-route-deployment/govern-with-timelocks.mdx
@@ -58,7 +58,9 @@ Timelocks do not replace good key management, good ISM design, or monitoring. Th
 
 ## Hyperlane setup
 
-A typical setup uses one governance Safe on an owner chain, usually Ethereum, and one timelock on each chain where contracts are governed.
+A typical setup starts with one governance Safe on an owner chain, usually Ethereum. For contracts on that same chain, the Safe can govern directly. For contracts on remote chains, the Safe uses an [Interchain Account (ICA)](/docs/applications/interchain-account) to make authenticated calls on the remote chain.
+
+Timelocks are then added as the owner of each governed contract. The Safe or ICA does not execute owner actions immediately. Instead, it proposes actions to the timelock, and the timelock enforces the delay and cancellation window before execution.
 
 ```mermaid
 flowchart LR
@@ -87,7 +89,11 @@ flowchart LR
   Executor -. "execute ready operation" .-> RemoteTimelock
 ```
 
-There are two governance paths: same-chain governance for contracts on the owner chain, and ICA-based governance for contracts on remote chains.
+There are three pieces in the governance path:
+
+- Same-chain multisig governance: the owner-chain Safe is the source of governance decisions.
+- ICA-based remote governance: the Safe controls remote-chain ICAs so it can govern contracts on other chains from the owner chain.
+- Timelock-controlled ownership: each governed contract is owned by its local timelock, which delays execution and allows cancellation.
 
 For same-chain governance:
 
@@ -98,7 +104,7 @@ For same-chain governance:
 For remote-chain governance:
 
 - The governed contract is owned by a timelock on that remote chain.
-- The proposer is an [Interchain Account (ICA)](/docs/applications/interchain-account) on that remote chain.
+- The proposer is an ICA on that remote chain.
 - That ICA is controlled by the governance Safe on the owner chain.
 - The Safe sends an ICA message, and the ICA schedules the action on the remote timelock.
 

--- a/docs/guides/production/warp-route-deployment/govern-with-timelocks.mdx
+++ b/docs/guides/production/warp-route-deployment/govern-with-timelocks.mdx
@@ -87,16 +87,18 @@ flowchart LR
   Executor -. "execute ready operation" .-> RemoteTimelock
 ```
 
-On the owner chain:
+There are two governance paths: same-chain governance for contracts on the owner chain, and ICA-based governance for contracts on remote chains.
+
+For same-chain governance:
 
 - The governed contract is owned by the timelock on that same chain.
 - The governance Safe has `PROPOSER_ROLE` on that timelock.
 - The Safe schedules actions directly on the timelock.
 
-On each remote EVM chain:
+For remote-chain governance:
 
 - The governed contract is owned by a timelock on that remote chain.
-- The proposer is an Interchain Account (ICA) on that remote chain.
+- The proposer is an [Interchain Account (ICA)](/docs/applications/interchain-account) on that remote chain.
 - That ICA is controlled by the governance Safe on the owner chain.
 - The Safe sends an ICA message, and the ICA schedules the action on the remote timelock.
 

--- a/docs/guides/production/warp-route-deployment/transfer-warp-route-ownership.mdx
+++ b/docs/guides/production/warp-route-deployment/transfer-warp-route-ownership.mdx
@@ -43,7 +43,8 @@ One of the quickest way to transfer a HWR ownership is by using the [Hyperlane C
   If you followed the [Deploy a Warp
   Route](/docs/guides/quickstart/deploy-warp-route) guide, you may have deployed
   a HWR with the owner set to the single private key. In production, it is
-  advisable to use a multisig.
+  advisable to use a multisig or a
+  [governance timelock](/docs/guides/production/warp-route-deployment/govern-with-timelocks).
 </Info>
 
 To confirm using the Hyperlane CLI, locate your token symbol and the chain it is deployed on:


### PR DESCRIPTION
## Summary
- add a production guide explaining OpenZeppelin timelock governance for Warp Route and chain owners
- document Safe/ICA proposer setup, permissionless execution, cancellers, and submitter strategy usage
- link the guide from production overview and Warp Route ownership docs

## Validation
- jq empty docs.json
- git diff --check