### PR TITLE
docs: add Matchain and update TAC removal date

### DIFF
--- a/docs/reference/deprecated-chains.mdx
+++ b/docs/reference/deprecated-chains.mdx
@@ -52,6 +52,7 @@ Abacus Works is winding down its [Relayer](/docs/protocol/agents/relayer) and [V
 | Lit Chain             | 175200     | 175200      | June 16, 2026       |
 | Lumia Prism           | 1000073017 | 994873017   | August 14, 2026     |
 | Manta Pacific         | 169        | 169         | July 10, 2026       |
+| Matchain              | 698        | 698         | August 14, 2026     |
 | MegaETH               | 4326       | 4326        | September 30, 2026  |
 | Merlin                | 4200       | 4200        | May 10, 2026        |
 | MilkyWay              | 1835625579 | milkyway    | May 10, 2026        |
@@ -85,7 +86,7 @@ Abacus Works is winding down its [Relayer](/docs/protocol/agents/relayer) and [V
 | Stride                | 745        | stride-1    | July 10, 2026       |
 | Superposition         | 1000055244 | 55244       | May 10, 2026        |
 | Swellchain            | 1923       | 1923        | June 28, 2026       |
-| TAC                   | 239        | 239         | August 14, 2026     |
+| TAC                   | 239        | 239         | August 28, 2026     |
 | Taiko                 | 167000     | 167000      | September 30, 2026  |
 | Tangle                | 5845       | 5845        | May 10, 2026        |
 | Torus                 | 21000      | 21000       | July 10, 2026       |


### PR DESCRIPTION
## Summary
- Add Matchain (698 / 698) to deprecated chains, last supported Aug 14, 2026
- Update TAC's last supported date from Aug 14 to Aug 28, 2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)